### PR TITLE
fix: invalid PowerShell syntax causing Windows sound playback failure

### DIFF
--- a/src/sound.ts
+++ b/src/sound.ts
@@ -71,7 +71,7 @@ async function playOnMac(soundPath: string): Promise<void> {
 }
 
 async function playOnWindows(soundPath: string): Promise<void> {
-  const script = `(New-Object Media.SoundPlayer $args[0]).PlaySync()`
+  const script = `& { (New-Object Media.SoundPlayer $args[0]).PlaySync() }`
   await runCommand("powershell", ["-c", script, soundPath])
 }
 


### PR DESCRIPTION
## Summary
Fixes #4

Wraps the PowerShell command in a script block `& { ... }` so that `$args` can be correctly passed and accessed.

## Changes
- Updated `playOnWindows` in `src/sound.ts` to use `& { (New-Object Media.SoundPlayer $args[0]).PlaySync() }`

## Verification
- Validated locally on Windows environment where the original code failed with `Unexpected token`.