### PR TITLE
fixes notifications not appearing on (some) macs

### DIFF
--- a/src/notify.ts
+++ b/src/notify.ts
@@ -13,7 +13,7 @@ if (platform === "Linux" || platform.match(/BSD$/)) {
   platformNotifier = new NotifySend({ withFallback: false })
 } else if (platform === "Darwin") {
   const { NotificationCenter } = notifier
-  platformNotifier = new NotificationCenter({ withFallback: false })
+  platformNotifier = new NotificationCenter({ withFallback: true })
 } else if (platform === "Windows_NT") {
   const { WindowsToaster } = notifier
   platformNotifier = new WindowsToaster({ withFallback: false })
@@ -47,7 +47,8 @@ export async function sendNotification(
 
     platformNotifier.notify(
       notificationOptions,
-      () => {
+      (error: any, response: any) => {
+        if (error) console.error(error)
         resolve()
       }
     )


### PR DESCRIPTION
With this change, now notifications appear on my mac too. 
Before, I was only hearing sounds.