### PR TITLE
refactor: enable bundled sounds by default and improve path resolution

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -31,12 +31,12 @@ export interface NotifierConfig {
 }
 
 const DEFAULT_EVENT_CONFIG: EventConfig = {
-  sound: false,
+  sound: true,
   notification: true,
 }
 
 const DEFAULT_CONFIG: NotifierConfig = {
-  sound: false,
+  sound: true,
   notification: true,
   timeout: 5,
   events: {

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -11,7 +11,20 @@ const DEBOUNCE_MS = 1000
 const lastSoundTime: Record<string, number> = {}
 
 function getBundledSoundPath(event: EventType): string {
-  return join(__dirname, "..", "sounds", `${event}.wav`)
+  const soundFilename = `${event}.wav`
+
+  const possiblePaths = [
+    join(__dirname, "..", "sounds", soundFilename),
+    join(__dirname, "sounds", soundFilename),
+  ]
+
+  for (const path of possiblePaths) {
+    if (existsSync(path)) {
+      return path
+    }
+  }
+
+  return join(__dirname, "..", "sounds", soundFilename)
 }
 
 function getSoundFilePath(event: EventType, customPath: string | null): string | null {


### PR DESCRIPTION
## Summary
- Enable sounds by default for better out-of-the-box experience
- Improve sound file path resolution to handle different installation structures

## Changes
- Set `sound: true` as default in `config.ts`
- Add fallback path resolution in `getBundledSoundPath()` to check multiple locations

## Verification
- Tested locally on Linux with all 3 sounds (complete, error, permission)
- No impact on macOS or Windows - only affects path resolution, not playback commands