### PR TITLE
docs: update macOS troubleshooting to reference Script Editor instead of terminal-notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,17 +190,10 @@ If a custom sound file path is provided but the file doesn't exist, the plugin w
 
 If notifications still don't work after updating:
 
-1. **Install terminal-notifier via Homebrew:**
-
-   ```bash
-   brew install terminal-notifier
-   ```
-
-2. **Check notification permissions:**
+1. **Check notification permissions:**
    - Open **System Settings > Notifications**
-   - Find your terminal app (e.g., Ghostty, iTerm2, Terminal)
+   - Find **Script Editor** in the list
    - Make sure notifications are set to **Banners** or **Alerts**
-   - Also enable notifications for **terminal-notifier** if it appears in the list
 
 ### Linux: Notifications not showing
 


### PR DESCRIPTION
# Context
Since https://github.com/mohak34/opencode-notifier/commit/23234e3cfff142a5ee042aa1c85719c460541e67, macOS no longer uses `terminal-notifier` and uses `osascript` so the current documentation seemed quite misleading. 

# Changes
* Removed the outdated instruction to install terminal-notifier via Homebrew
* Changed the notification permissions guidance to reference Script Editor instead of `terminal-notifier`