### PR TITLE
feat: include session title in notification messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Create `~/.config/opencode/opencode-notifier.json` with the defaults:
   "notification": true,
   "timeout": 5,
   "showProjectName": true,
+  "showSessionTitle": true,
   "showIcon": true,
   "notificationSystem": "osascript",
   "command": {
@@ -68,11 +69,11 @@ Create `~/.config/opencode/opencode-notifier.json` with the defaults:
     "question": { "sound": true, "notification": true }
   },
   "messages": {
-    "permission": "Session needs permission",
-    "complete": "Session has finished",
-    "subagent_complete": "Subagent task completed",
-    "error": "Session encountered an error",
-    "question": "Session has a question"
+    "permission": "Session needs permission: {sessionTitle}",
+    "complete": "Session has finished: {sessionTitle}",
+    "subagent_complete": "Subagent task completed: {sessionTitle}",
+    "error": "Session encountered an error: {sessionTitle}",
+    "question": "Session has a question: {sessionTitle}"
   },
   "sounds": {
     "permission": null,
@@ -94,6 +95,7 @@ Create `~/.config/opencode/opencode-notifier.json` with the defaults:
   "notification": true,
   "timeout": 5,
   "showProjectName": true,
+  "showSessionTitle": true,
   "showIcon": true,
   "notificationSystem": "osascript"
 }
@@ -103,6 +105,7 @@ Create `~/.config/opencode/opencode-notifier.json` with the defaults:
 - `notification` - Turn notifications on/off (default: true)
 - `timeout` - How long notifications show in seconds, Linux only (default: 5)
 - `showProjectName` - Show folder name in notification title (default: true)
+- `showSessionTitle` - Include the session title in notification messages via `{sessionTitle}` placeholder (default: true)
 - `showIcon` - Show OpenCode icon, Windows/Linux only (default: true)
 - `notificationSystem` - macOS only: `"osascript"` or `"node-notifier"` (default: "osascript")
 
@@ -139,14 +142,23 @@ Customize the notification text:
 ```json
 {
   "messages": {
-    "permission": "Session needs permission",
-    "complete": "Session has finished",
-    "subagent_complete": "Subagent task completed",
-    "error": "Session encountered an error",
-    "question": "Session has a question"
+    "permission": "Session needs permission: {sessionTitle}",
+    "complete": "Session has finished: {sessionTitle}",
+    "subagent_complete": "Subagent task completed: {sessionTitle}",
+    "error": "Session encountered an error: {sessionTitle}",
+    "question": "Session has a question: {sessionTitle}"
   }
 }
 ```
+
+Messages support placeholder tokens that get replaced with actual values:
+
+- `{sessionTitle}` - The title/summary of the current session (e.g. "Fix login bug")
+- `{projectName}` - The project folder name
+
+When `showSessionTitle` is `false`, `{sessionTitle}` is replaced with an empty string. Any trailing separators (`: `, ` - `, ` | `) are automatically cleaned up when a placeholder resolves to empty.
+
+To disable session titles in messages without changing `showSessionTitle`, just remove the `{sessionTitle}` placeholder from your custom messages.
 
 ### Sounds
 
@@ -171,7 +183,7 @@ Platform notes:
 
 ### Custom commands
 
-Run your own script when something happens. Use `{event}` and `{message}` as placeholders:
+Run your own script when something happens. Use `{event}`, `{message}`, and `{sessionTitle}` as placeholders:
 
 ```json
 {
@@ -186,7 +198,7 @@ Run your own script when something happens. Use `{event}` and `{message}` as pla
 
 - `enabled` - Turn command on/off
 - `path` - Path to your script/executable
-- `args` - Arguments to pass, can use `{event}` and `{message}` tokens
+- `args` - Arguments to pass, can use `{event}`, `{message}`, and `{sessionTitle}` tokens
 - `minDuration` - Skip if response was quick, avoids spam (seconds)
 
 #### Example: Log events to a file

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,17 +1,19 @@
 import { spawn } from "child_process"
 import type { EventType, NotifierConfig } from "./config"
 
-function substituteTokens(value: string, event: EventType, message: string): string {
-  return value.replaceAll("{event}", event).replaceAll("{message}", message)
+function substituteTokens(value: string, event: EventType, message: string, sessionTitle?: string | null): string {
+  let result = value.replaceAll("{event}", event).replaceAll("{message}", message)
+  result = result.replaceAll("{sessionTitle}", sessionTitle || "")
+  return result
 }
 
-export function runCommand(config: NotifierConfig, event: EventType, message: string): void {
+export function runCommand(config: NotifierConfig, event: EventType, message: string, sessionTitle?: string | null): void {
   if (!config.command.enabled || !config.command.path) {
     return
   }
 
-  const args = (config.command.args ?? []).map((arg) => substituteTokens(arg, event, message))
-  const command = substituteTokens(config.command.path, event, message)
+  const args = (config.command.args ?? []).map((arg) => substituteTokens(arg, event, message, sessionTitle))
+  const command = substituteTokens(config.command.path, event, message, sessionTitle)
 
   const proc = spawn(command, args, {
     stdio: "ignore",

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,11 +17,17 @@ export interface CommandConfig {
   minDuration?: number
 }
 
+export interface MessageContext {
+  sessionTitle?: string | null
+  projectName?: string | null
+}
+
 export interface NotifierConfig {
   sound: boolean
   notification: boolean
   timeout: number
   showProjectName: boolean
+  showSessionTitle: boolean
   showIcon: boolean
   notificationSystem: "osascript" | "node-notifier"
   command: CommandConfig
@@ -58,6 +64,7 @@ const DEFAULT_CONFIG: NotifierConfig = {
   notification: true,
   timeout: 5,
   showProjectName: true,
+  showSessionTitle: true,
   showIcon: true,
   notificationSystem: "osascript",
   command: {
@@ -73,11 +80,11 @@ const DEFAULT_CONFIG: NotifierConfig = {
     question: { ...DEFAULT_EVENT_CONFIG },
   },
   messages: {
-    permission: "Session needs permission",
-    complete: "Session has finished",
-    subagent_complete: "Subagent task completed",
-    error: "Session encountered an error",
-    question: "Session has a question",
+    permission: "Session needs permission: {sessionTitle}",
+    complete: "Session has finished: {sessionTitle}",
+    subagent_complete: "Subagent task completed: {sessionTitle}",
+    error: "Session encountered an error: {sessionTitle}",
+    question: "Session has a question: {sessionTitle}",
   },
   sounds: {
     permission: null,
@@ -152,6 +159,7 @@ export function loadConfig(): NotifierConfig {
           ? userConfig.timeout
           : DEFAULT_CONFIG.timeout,
       showProjectName: userConfig.showProjectName ?? DEFAULT_CONFIG.showProjectName,
+      showSessionTitle: userConfig.showSessionTitle ?? DEFAULT_CONFIG.showSessionTitle,
       showIcon: userConfig.showIcon ?? DEFAULT_CONFIG.showIcon,
       notificationSystem: userConfig.notificationSystem === "node-notifier" ? "node-notifier" : "osascript",
       command: {
@@ -221,4 +229,22 @@ export function getIconPath(config: NotifierConfig): string | undefined {
   }
   
   return undefined
+}
+
+export function interpolateMessage(message: string, context: MessageContext): string {
+  let result = message
+
+  const sessionTitle = context.sessionTitle || ""
+  result = result.replaceAll("{sessionTitle}", sessionTitle)
+
+  const projectName = context.projectName || ""
+  result = result.replaceAll("{projectName}", projectName)
+
+  // Clean up artifacts from empty placeholder replacements
+  // Remove trailing separators like ": ", " - ", " | " left after empty substitution
+  result = result.replace(/\s*[:\-|]\s*$/, "").trim()
+  // Collapse multiple spaces into one
+  result = result.replace(/\s{2,}/g, " ")
+
+  return result
 }


### PR DESCRIPTION
## Summary

- Adds `{sessionTitle}` placeholder support in notification messages, so users can identify **which session** triggered the notification (e.g. "Session has finished: Fix login bug")
- Adds `showSessionTitle` config option (`true` by default) to control whether session titles are resolved
- Supports `{sessionTitle}` token in custom command `args` for consistency with existing `{event}` and `{message}` tokens

## Changes

### `src/config.ts`
- Added `MessageContext` interface and `interpolateMessage()` function for placeholder substitution
- Added `showSessionTitle: boolean` to `NotifierConfig` (default: `true`)
- Updated default messages to include `{sessionTitle}` placeholder (e.g. `"Session has finished: {sessionTitle}"`)
- Auto-cleans trailing separators (`: `, ` - `, ` | `) when a placeholder resolves to empty string

### `src/index.ts`
- Refactored `isChildSession()` into `getSessionInfo()` returning `{ isChild, title }` to avoid duplicate API calls
- `handleEvent()` now accepts optional `sessionTitle` and runs `interpolateMessage()` before sending notifications
- `handleEventWithElapsedTime()` looks up session title via `client.session.get()` when not pre-loaded
- `session.idle` handler passes pre-loaded title from `getSessionInfo()` to avoid a second API call

### `src/command.ts`
- Added `{sessionTitle}` token support in `substituteTokens()` for custom command args

### `README.md`
- Documented `showSessionTitle` option
- Documented `{sessionTitle}` and `{projectName}` message placeholders
- Updated config examples with new defaults

## Backwards Compatibility

- Users with **custom messages** (no `{sessionTitle}` placeholder) → **no change**, their messages work exactly as before
- Users relying on **default messages** → will now see session titles appended (e.g. `"Session has finished: Fix login bug"`)
- If session title is unavailable (e.g. hooks without session context), the placeholder resolves to empty and trailing separators are cleaned up automatically
- Setting `showSessionTitle: false` disables title resolution entirely