### PR TITLE
fix: prevent overlapping error and completion notifications

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@mohak34/opencode-notifier",


### PR DESCRIPTION
## Summary
- fix duplicate sound playback when a task is canceled with `Esc`
- prevent stale `session.idle` completion notifications from firing right after `session.error`
- introduce session-scoped idle sequencing and one-shot suppression tied to `session.status = busy`
- keep `minDuration` command gating accurate by evaluating elapsed time at idle-receive time
- include Bun lockfile metadata update (`configVersion: 0`)

## Problem
When users cancel a running task with `Esc`, OpenCode can emit `session.idle` and `session.error` very close together. This could cause both completion and error sounds/notifications to play for one canceled run.

## Root Cause
- completion handling relied on session-level timing behavior that could not reliably separate stale idle callbacks from new work
- elapsed duration for `minDuration` was computed after the idle delay, which could skew threshold behavior

## What Changed
- added session idle sequencing (`sessionIdleSequence`) and timer invalidation to drop stale idle callbacks
- added one-shot error suppression (`sessionErrorSuppressionAt`) and explicit reset on next busy state (`sessionLastBusyAt`)
- gated idle completion processing both before and after child-session lookup to prevent race emissions
- passed an explicit elapsed-time reference (`elapsedReferenceNowMs`) so `minDuration` is not inflated by idle delay

## Behavior After Fix
- `Esc` cancellation no longer produces overlapping completion + error sounds
- error notifications/sounds still emit immediately for real errors
- stale post-error idle completion events are suppressed
- a new run (`busy -> idle`) still emits normal completion/subagent completion
- command execution skip/run behavior for `minDuration` remains consistent with actual response time

## Validation
- `bun run typecheck`
- `bun run build`
- manual local verification with restart + `Esc` cancellation repro + quick retry repro

## Notes
- no public API changes
- lockfile includes Bun metadata line: `configVersion: 0`