### PR TITLE
feat: add Ghostty notification system support

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -33,7 +33,7 @@ export interface NotifierConfig {
   showProjectName: boolean
   showSessionTitle: boolean
   showIcon: boolean
-  notificationSystem: "osascript" | "node-notifier"
+  notificationSystem: "osascript" | "node-notifier" | "ghostty"
   linux: LinuxConfig
   command: CommandConfig
   events: {
@@ -82,7 +82,7 @@ const DEFAULT_CONFIG: NotifierConfig = {
   showProjectName: true,
   showSessionTitle: false,
   showIcon: true,
-  notificationSystem: "osascript",
+  notificationSystem: "osascript" as const,
   linux: {
     grouping: false,
   },
@@ -210,7 +210,12 @@ export function loadConfig(): NotifierConfig {
       showProjectName: userConfig.showProjectName ?? DEFAULT_CONFIG.showProjectName,
       showSessionTitle: userConfig.showSessionTitle ?? DEFAULT_CONFIG.showSessionTitle,
       showIcon: userConfig.showIcon ?? DEFAULT_CONFIG.showIcon,
-      notificationSystem: userConfig.notificationSystem === "node-notifier" ? "node-notifier" : "osascript",
+      notificationSystem:
+        userConfig.notificationSystem === "node-notifier"
+          ? "node-notifier"
+          : userConfig.notificationSystem === "ghostty"
+            ? "ghostty"
+            : "osascript",
       linux: {
         grouping: typeof userConfig.linux?.grouping === "boolean" ? userConfig.linux.grouping : DEFAULT_CONFIG.linux.grouping,
       },

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -85,7 +85,7 @@ export async function sendNotification(
   message: string,
   timeout: number,
   iconPath?: string,
-  notificationSystem: "osascript" | "node-notifier" = "osascript",
+  notificationSystem: "osascript" | "node-notifier" | "ghostty" = "osascript",
   linuxGrouping: boolean = true
 ): Promise<void> {
   const now = Date.now()
@@ -93,6 +93,16 @@ export async function sendNotification(
     return
   }
   lastNotificationTime[message] = now
+
+  if (notificationSystem === "ghostty") {
+    return new Promise((resolve) => {
+      const escapedTitle = title.replace(/[;\x07\x1b]/g, "")
+      const escapedMessage = message.replace(/[;\x07\x1b]/g, "")
+      process.stdout.write(`\x1b]777;notify;${escapedTitle};${escapedMessage}\x07`, () => {
+        resolve()
+      })
+    })
+  }
 
   if (platform === "Darwin") {
     if (notificationSystem === "node-notifier") {


### PR DESCRIPTION
## Summary

- Adds `"ghostty"` as a new `notificationSystem` option alongside `"osascript"` and `"node-notifier"`
- Uses the [OSC 777 escape sequence](https://github.com/ghostty-org/ghostty/discussions/3555#discussioncomment-11687079) (`\e]777;notify;title;body\a`) to send notifications natively through Ghostty terminal
- Clicking notifications brings the Ghostty window to the foreground, unlike `osascript` which opens Script Editor

## Usage

Set in `~/.config/opencode/opencode-notifier.json`:

```json
{
  "notificationSystem": "ghostty"
}
```

## Changes

- `src/config.ts`: Added `"ghostty"` to the `notificationSystem` type union and config parsing
- `src/notify.ts`: Added Ghostty handler that writes the OSC 777 escape sequence to stdout, with sanitization of control characters (`;`, BEL, ESC)

## Testing

Tested locally on macOS with Ghostty — notifications appear as native macOS notifications from Ghostty, and clicking them correctly brings the terminal window to the foreground, even to the correct tab if you have multiple opencodes running simultaneously.