### PR TITLE
feat: prevent notifications on Desktop and Web clients

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -351,6 +351,11 @@ async function handleEventWithElapsedTime(
 }
 
 export const NotifierPlugin: Plugin = async ({ client, directory }) => {
+  if (process.env.OPENCODE_CLIENT !== "cli") {
+    // OpenCode on Desktop and Web already have built-in notifications.
+    return {}
+  }
+
   const getConfig = () => loadConfig()
   const projectName = directory ? basename(directory) : null
 


### PR DESCRIPTION
Introduces an environment check to prevent duplicate notifications that already have built-in notification support. The main change ensures that the notification plugin only runs in the CLI environment.