### PR TITLE
Fix the issue where the bundled index.js contains source file paths.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "logos"
   ],
   "scripts": {
-    "build": "bun build src/index.ts --outdir dist --target node",
+    "build": "bun build src/index.ts --outdir dist --target node --external node-notifier",
     "prepublishOnly": "bun run build",
     "typecheck": "tsc --noEmit",
     "test": "bun test"


### PR DESCRIPTION
```bash
$ cat dist/index.js|grep home
  var __dirname = "/home/strix/Workspace/Projects/opencode-notifier/node_modules/node-notifier/notifiers";
  var __dirname = "/home/strix/Workspace/Projects/opencode-notifier/node_modules/node-notifier/notifiers";
  var __dirname = "/home/strix/Workspace/Projects/opencode-notifier/node_modules/node-notifier/notifiers";
import { homedir } from "os";
  return join(homedir(), ".config", "opencode", "opencode-notifier.json");

```