### PR TITLE
fix: disable mpv autoload script for single sound playback

### DIFF
--- a/src/sound.ts
+++ b/src/sound.ts
@@ -93,7 +93,7 @@ async function playOnLinux(soundPath: string, volume: number): Promise<void> {
   const players = [
     { command: "paplay", args: [`--volume=${pulseVolume}`, soundPath] },
     { command: "aplay", args: [soundPath] },
-    { command: "mpv", args: ["--no-video", "--no-terminal", `--volume=${percentVolume}`, soundPath] },
+    { command: "mpv", args: ["--no-video", "--no-terminal", "--script-opts=autoload-disabled=yes", `--volume=${percentVolume}`, soundPath] },
     { command: "ffplay", args: ["-nodisp", "-autoexit", "-loglevel", "quiet", "-volume", `${percentVolume}`, soundPath] },
   ]
 


### PR DESCRIPTION
`autoload` is one of mpv's most used scripts (being present in the [main repository](https://github.com/mpv-player/mpv/blob/master/TOOLS/lua/autoload.lua)) and, when it's enabled, the notifier plugin will play multiple sounds instead of only the desired one.

I've updated the command flags to specify `autoload-disabled=yes`, which should stop this behavior.