### PR TITLE
Set Linux notification app name to `opencode`

### DIFF
--- a/src/notify.ts
+++ b/src/notify.ts
@@ -52,7 +52,7 @@ function sendLinuxNotificationDirect(
   return new Promise((resolve) => {
     const args: string[] = []
 
-    args.push("-a", "opencode")
+    args.push("--app-name", "opencode")
 
     if (iconPath) {
       args.push("--icon", iconPath)


### PR DESCRIPTION
## Description

Update Linux notification calls to pass `opencode` as the app name for both notify-send and the notifier fallback, so desktop `notifications` show `opencode` instead of the default notify-send label.