### PR TITLE
feat: added niri window focus detection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,10 +320,11 @@ To disable this and always get notified:
 | macOS | AppleScript (`System Events`) | None | Untested |
 | Linux X11 | `xdotool` | `xdotool` installed | Untested |
 | Linux Wayland (Hyprland) | `hyprctl activewindow` | None | Tested |
+| Linux Wayland (Niri) | `niri msg --json focused-window` | None | Tested |
 | Linux Wayland (Sway) | `swaymsg -t get_tree` | None | Untested |
 | Linux Wayland (KDE) | `kdotool` | `kdotool` installed | Untested |
 | Linux Wayland (GNOME) | Not supported | - | Falls back to always notifying |
-| Linux Wayland (Niri, river, dwl, Cosmic, etc.) | Not supported | - | Falls back to always notifying |
+| Linux Wayland (river, dwl, Cosmic, etc.) | Not supported | - | Falls back to always notifying |
 | Windows | `GetForegroundWindow()` via PowerShell | None | Untested |
 
 **Unsupported compositors**: Wayland has no standard protocol for querying the focused window. Each compositor has its own IPC, and GNOME intentionally doesn't expose focus information. Unsupported compositors fall back to always notifying.

--- a/src/focus.ts
+++ b/src/focus.ts
@@ -78,9 +78,21 @@ function getSwayActiveWindowId(): string | null {
   }
 }
 
+function getNiriActiveWindowId(): string | null {
+  const output = execWithTimeout("niri msg --json focused-window", 1000)
+  if (!output) return null
+  try {
+    const data = JSON.parse(output)
+    return typeof data?.id === "number" ? String(data.id) : null
+  } catch {
+    return null
+  }
+}
+
 function getLinuxWaylandActiveWindowId(): string | null {
   const env = process.env
   if (env.HYPRLAND_INSTANCE_SIGNATURE) return getHyprlandActiveWindowId()
+  if (env.NIRI_SOCKET) return getNiriActiveWindowId()
   if (env.SWAYSOCK) return getSwayActiveWindowId()
   if (env.KDE_SESSION_VERSION) return execWithTimeout("kdotool getactivewindow")
   return null


### PR DESCRIPTION
This pull request adds support for detecting the active window on the Niri Wayland compositor. It updates both the documentation and the codebase to handle Niri specifically, allowing the application to identify the focused window when running under Niri.

Support for Niri compositor:

* Added a new function `getNiriActiveWindowId` in `src/focus.ts` to fetch the active window ID using the `niri msg --json focused-window` command, and updated `getLinuxWaylandActiveWindowId` to check for the `NIRI_SOCKET` environment variable and use this function when present.
* Updated the `README.md` to document support for Niri, specifying the requirements and marking it as tested