### PR TITLE
feat: 3 additional events, session_started, user_message, client_connected

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "build": "bun build src/index.ts --outdir dist --target node --external node-notifier",
     "prepublishOnly": "bun run build",
     "typecheck": "tsc --noEmit",
+    "patch_live_plugin": "bun run build && cp dist/index.js /home/grota/.cache/opencode/node_modules/@mohak34/opencode-notifier/dist/",
     "test": "bun test"
   },
   "keywords": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,18 @@ import { join, dirname } from "path"
 import { homedir } from "os"
 import { fileURLToPath } from "url"
 
-export type EventType = "permission" | "complete" | "subagent_complete" | "error" | "question" | "interrupted" | "user_cancelled" | "plan_exit"
+export type EventType = 
+  | "permission"
+  | "complete"
+  | "subagent_complete"
+  | "error"
+  | "question"
+  | "interrupted"
+  | "user_cancelled"
+  | "plan_exit"
+  | "session_started"
+  | "user_message"
+  | "client_connected"
 
 export interface EventConfig {
   sound: boolean
@@ -51,6 +62,9 @@ export interface NotifierConfig {
     interrupted: EventConfig
     user_cancelled: EventConfig
     plan_exit: EventConfig
+    session_started: EventConfig
+    user_message: EventConfig
+    client_connected: EventConfig
   }
   messages: {
     permission: string
@@ -61,6 +75,9 @@ export interface NotifierConfig {
     interrupted: string
     user_cancelled: string
     plan_exit: string
+    session_started: string
+    user_message: string
+    client_connected: string
   }
   sounds: {
     permission: string | null
@@ -71,6 +88,9 @@ export interface NotifierConfig {
     interrupted: string | null
     user_cancelled: string | null
     plan_exit: string | null
+    session_started: string | null
+    user_message: string | null
+    client_connected: string | null
   }
   volumes: {
     permission: number
@@ -81,6 +101,9 @@ export interface NotifierConfig {
     interrupted: number
     user_cancelled: number
     plan_exit: number
+    session_started: number
+    user_message: number
+    client_connected: number
   }
 }
 
@@ -117,6 +140,9 @@ const DEFAULT_CONFIG: NotifierConfig = {
     interrupted: { ...DEFAULT_EVENT_CONFIG },
     user_cancelled: { ...DEFAULT_EVENT_CONFIG, sound: false, notification: false },
     plan_exit: { ...DEFAULT_EVENT_CONFIG },
+    session_started: { ...DEFAULT_EVENT_CONFIG, notification: false },
+    user_message: { ...DEFAULT_EVENT_CONFIG, notification: false },
+    client_connected: { ...DEFAULT_EVENT_CONFIG, notification: false },
   },
   messages: {
     permission: "Session needs permission: {sessionTitle}",
@@ -127,6 +153,9 @@ const DEFAULT_CONFIG: NotifierConfig = {
     interrupted: "Session was interrupted: {sessionTitle}",
     user_cancelled: "Session was cancelled by user: {sessionTitle}",
     plan_exit: "Plan ready for review: {sessionTitle}",
+    session_started: "Session started: {sessionTitle}",
+    user_message: "User sent a message: {sessionTitle}",
+    client_connected: "OpenCode connected",
   },
   sounds: {
     permission: null,
@@ -137,6 +166,9 @@ const DEFAULT_CONFIG: NotifierConfig = {
     interrupted: null,
     user_cancelled: null,
     plan_exit: null,
+    session_started: null,
+    user_message: null,
+    client_connected: null,
   },
   volumes: {
     permission: 1,
@@ -147,6 +179,9 @@ const DEFAULT_CONFIG: NotifierConfig = {
     interrupted: 1,
     user_cancelled: 1,
     plan_exit: 1,
+    session_started: 1,
+    user_message: 1,
+    client_connected: 1,
   },
 }
 
@@ -269,6 +304,9 @@ export function loadConfig(): NotifierConfig {
         interrupted: parseEventConfig(userConfig.events?.interrupted ?? userConfig.interrupted, defaultWithGlobal),
         user_cancelled: parseEventConfig(userConfig.events?.user_cancelled ?? userConfig.user_cancelled, { sound: false, notification: false, command: true }),
         plan_exit: parseEventConfig(userConfig.events?.plan_exit ?? userConfig.plan_exit, defaultWithGlobal),
+        session_started: parseEventConfig(userConfig.events?.session_started ?? userConfig.session_started, { ...defaultWithGlobal, notification: false }),
+        user_message: parseEventConfig(userConfig.events?.user_message ?? userConfig.user_message, { ...defaultWithGlobal, notification: false }),
+        client_connected: parseEventConfig(userConfig.events?.client_connected ?? userConfig.client_connected, { ...defaultWithGlobal, notification: false }),
       },
       messages: {
         permission: userConfig.messages?.permission ?? DEFAULT_CONFIG.messages.permission,
@@ -279,6 +317,9 @@ export function loadConfig(): NotifierConfig {
         interrupted: userConfig.messages?.interrupted ?? DEFAULT_CONFIG.messages.interrupted,
         user_cancelled: userConfig.messages?.user_cancelled ?? DEFAULT_CONFIG.messages.user_cancelled,
         plan_exit: userConfig.messages?.plan_exit ?? DEFAULT_CONFIG.messages.plan_exit,
+        session_started: userConfig.messages?.session_started ?? DEFAULT_CONFIG.messages.session_started,
+        user_message: userConfig.messages?.user_message ?? DEFAULT_CONFIG.messages.user_message,
+        client_connected: userConfig.messages?.client_connected ?? DEFAULT_CONFIG.messages.client_connected,
       },
       sounds: {
         permission: userConfig.sounds?.permission ?? DEFAULT_CONFIG.sounds.permission,
@@ -289,6 +330,9 @@ export function loadConfig(): NotifierConfig {
         interrupted: userConfig.sounds?.interrupted ?? DEFAULT_CONFIG.sounds.interrupted,
         user_cancelled: userConfig.sounds?.user_cancelled ?? DEFAULT_CONFIG.sounds.user_cancelled,
         plan_exit: userConfig.sounds?.plan_exit ?? DEFAULT_CONFIG.sounds.plan_exit,
+        session_started: userConfig.sounds?.session_started ?? DEFAULT_CONFIG.sounds.session_started,
+        user_message: userConfig.sounds?.user_message ?? DEFAULT_CONFIG.sounds.user_message,
+        client_connected: userConfig.sounds?.client_connected ?? DEFAULT_CONFIG.sounds.client_connected,
       },
       volumes: {
         permission: parseVolume(userConfig.volumes?.permission, DEFAULT_CONFIG.volumes.permission),
@@ -302,6 +346,9 @@ export function loadConfig(): NotifierConfig {
         interrupted: parseVolume(userConfig.volumes?.interrupted, DEFAULT_CONFIG.volumes.interrupted),
         user_cancelled: parseVolume(userConfig.volumes?.user_cancelled, DEFAULT_CONFIG.volumes.user_cancelled),
         plan_exit: parseVolume(userConfig.volumes?.plan_exit, DEFAULT_CONFIG.volumes.plan_exit),
+        session_started: parseVolume(userConfig.volumes?.session_started, DEFAULT_CONFIG.volumes.session_started),
+        user_message: parseVolume(userConfig.volumes?.user_message, DEFAULT_CONFIG.volumes.user_message),
+        client_connected: parseVolume(userConfig.volumes?.client_connected, DEFAULT_CONFIG.volumes.client_connected),
       },
     }
   } catch {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ const pendingIdleTimers = new Map<string, ReturnType<typeof setTimeout>>()
 const sessionIdleSequence = new Map<string, number>()
 const sessionErrorSuppressionAt = new Map<string, number>()
 const sessionLastBusyAt = new Map<string, number>()
+const subagentSessionIds = new Set<string>()
 
 let globalTurnCount: number | null = null
 
@@ -64,6 +65,8 @@ setInterval(() => {
     // If not in pendingIdleTimers, it's likely stale
     if (!pendingIdleTimers.has(sessionID)) {
       sessionIdleSequence.delete(sessionID)
+      // Also remove from subagent tracking if stale
+      subagentSessionIds.delete(sessionID)
     }
   }
 
@@ -310,6 +313,13 @@ async function processSessionIdle(
     return
   }
 
+  // Fast path: if we already know this is a subagent from in-memory tracking,
+  // skip the API call and go straight to subagent_complete
+  if (subagentSessionIds.has(sessionID)) {
+    await handleEventWithElapsedTime(client, config, "subagent_complete", projectName, event, idleReceivedAtMs, null)
+    return
+  }
+
   const sessionInfo = await getSessionInfo(client, sessionID)
 
   if (!hasCurrentSessionIdleSequence(sessionID, sequence)) {
@@ -325,6 +335,8 @@ async function processSessionIdle(
     return
   }
 
+  // Update in-memory set now that we confirmed it's a child via API
+  subagentSessionIds.add(sessionID)
   await handleEventWithElapsedTime(client, config, "subagent_complete", projectName, event, idleReceivedAtMs, sessionInfo.title)
 }
 
@@ -395,9 +407,43 @@ export const NotifierPlugin: Plugin = async ({ client, directory }) => {
   const getConfig = () => loadConfig()
   const projectName = directory ? basename(directory) : null
 
+  // Fire client_connected after the plugin is fully initialized.
+  // There is no SDK event that reliably signals client connection from a plugin's
+  // perspective, so we approximate it with a short delay after plugin startup.
+  // Config is read at fire-time so that any user overrides are respected.
+  setTimeout(() => {
+    void handleEvent(getConfig(), "client_connected", projectName, null)
+  }, 100)
+
   return {
     event: async ({ event }) => {
       const config = getConfig()
+
+      // Track subagent sessions from session lifecycle events
+      if (event.type === "session.created") {
+        const info = event.properties?.info
+        if (info?.parentID) {
+          subagentSessionIds.add(info.id)
+        } else {
+          // Non-subagent session started
+          await handleEvent(config, "session_started", projectName, null, info?.title ?? null, info?.id ?? null, null)
+        }
+      }
+
+      if (event.type === "session.updated") {
+        const info = event.properties?.info
+        if (info?.parentID && info?.id) {
+          subagentSessionIds.add(info.id)
+        }
+      }
+
+      if (event.type === "session.deleted") {
+        const info = event.properties?.info
+        if (info?.id) {
+          subagentSessionIds.delete(info.id)
+        }
+      }
+
       if ((event as any).type === "permission.asked") {
         const sessionID = getSessionIDFromEvent(event)
         if (!shouldSuppressPermissionAlert(sessionID)) {
@@ -428,6 +474,17 @@ export const NotifierPlugin: Plugin = async ({ client, directory }) => {
           sessionTitle = info.title
         }
         await handleEventWithElapsedTime(client, config, eventType, projectName, event, undefined, sessionTitle)
+      }
+
+      if (event.type === "message.updated") {
+        const role = (event as any).properties?.info?.role
+        if (role === "user") {
+          const sessionID = (event as any).properties?.info?.sessionID ?? null
+          // Only fire for non-subagent sessions
+          if (!sessionID || !subagentSessionIds.has(sessionID)) {
+            await handleEvent(config, "user_message", projectName, null, null, sessionID, null)
+          }
+        }
       }
     },
     "permission.ask": async () => {


### PR DESCRIPTION
## Summary

Adds three new configurable event types and improves subagent detection performance by introducing in-memory session tracking.

## New events

| Event type | Trigger | Default |
|---|---|---|
| `session_started` | A new top-level (non-subagent) session is opened (`session.created`) | sound only |
| `user_message` | The user submits a message in a top-level session (`message.updated`, role=user) | sound only |
| `client_connected` | The OpenCode plugin finishes initializing and is ready | sound only |

All three default to **sound enabled, notification disabled** to avoid notification spam for high-frequency or low-urgency events. Users can override each individually in `opencode-notifier.json`.

### Note on `client_connected`

There is no SDK event that reliably signals client connection from a plugin's perspective. The implementation fires the event via a short `setTimeout` after plugin startup, which is the closest available approximation. Config is read at fire-time (not schedule-time) so user overrides are respected, and the timeout only runs after the desktop-client guard has already passed.

## In-memory subagent tracking

Previously, every `session.idle` event required an API call (`client.session.get`) to determine whether the session was a subagent (by checking `parentID`). This PR introduces a module-level `subagentSessionIds: Set<string>` populated from `session.created`, `session.updated`, and `session.deleted` events.

- **Fast path**: if a session ID is already known to be a subagent, `processSessionIdle` returns immediately without any API call.
- **Fallback**: sessions not yet seen in the Set still go through the API call, and if confirmed as a subagent, are added to the Set for future events.
- The Set is pruned during the existing 5-minute cleanup interval alongside the other per-session maps.

## Configuration

The three new events are fully configurable like all existing events:

```json
{
  "events": {
    "session_started": { "sound": true, "notification": false, "command": true },
    "user_message": { "sound": false, "notification": false, "command": false },
    "client_connected": { "sound": true, "notification": true, "command": false }
  },
  "messages": {
    "session_started": "Session started: {sessionTitle}",
    "user_message": "User sent a message: {sessionTitle}",
    "client_connected": "OpenCode connected"
  },
  "sounds": {
    "session_started": "/path/to/custom.wav",
    "user_message": null,
    "client_connected": null
  },
  "volumes": {
    "session_started": 0.5,
    "user_message": 0.3,
    "client_connected": 1.0
  }
}
```

## Changes

- `src/config.ts`: Added `session_started`, `user_message`, and `client_connected` to `EventType`, `NotifierConfig`, `DEFAULT_CONFIG`, and `loadConfig()`.
- `src/index.ts`:
  - Added `subagentSessionIds: Set<string>` for in-memory subagent tracking.
  - Handle `session.created`: register subagent IDs; fire `session_started` for top-level sessions.
  - Handle `session.updated` / `session.deleted`: keep the subagent Set accurate.
  - Handle `message.updated`: fire `user_message` when `role === "user"` for non-subagent sessions.
  - Fire `client_connected` via `setTimeout` after plugin initialization (inside the desktop-client guard).
  - Updated `processSessionIdle` to use the fast path before falling back to the API.

## Tests

All 43 tests pass. No new test failures introduced.
