### PR TITLE
fix: correct WezTerm process name for macOS focus detection

### DIFF
--- a/src/focus.ts
+++ b/src/focus.ts
@@ -4,7 +4,7 @@ const MAC_TERMINAL_APP_NAMES = new Set<string>([
   "terminal",
   "iterm2",
   "ghostty",
-  "wezterm",
+  "wezterm-gui",
   "alacritty",
   "kitty",
   "hyper",
@@ -159,6 +159,8 @@ function getExpectedMacTerminalAppNames(env: NodeJS.ProcessEnv): Set<string> {
     expected.add("code insiders")
   } else if (termProgram === "warpterminal") {
     expected.add("warp")
+  } else if (termProgram === "wezterm") {
+    expected.add("wezterm-gui")
   } else if (termProgram.length > 0) {
     expected.add(termProgram)
   }


### PR DESCRIPTION
## Summary

Fixes `suppressWhenFocused` having no effect for WezTerm users on macOS.

Closes #63

## Problem

On macOS, `System Events` reports the `CFBundleExecutable` value as the process name. For WezTerm that value is `wezterm-gui` (defined in the app bundle's `Info.plist`), not `WezTerm` or `wezterm`.

The focus detection compared the frontmost app name against the expected terminal name derived from `TERM_PROGRAM=WezTerm`, which normalized to `"wezterm"`. Since `"wezterm-gui" !== "wezterm"`, `isMacTerminalAppFocused()` always returned `false` and notifications were never suppressed.

This affects all macOS WezTerm users regardless of install method (Homebrew cask, direct download, nightly) since the binary name is defined in the `.app` bundle itself.

## Fix

- Add a specific case for `TERM_PROGRAM=wezterm` in `getExpectedMacTerminalAppNames()` that adds `"wezterm-gui"` instead of falling through to the generic branch which adds `"wezterm"`
- Update `MAC_TERMINAL_APP_NAMES` (used as fallback when `TERM_PROGRAM` is unset) to use `"wezterm-gui"` for the same reason

## Verification

```sh
# Confirm what System Events returns for WezTerm on macOS
osascript -e 'tell application "System Events" to return name of first application process whose frontmost is true'
# => wezterm-gui
```