### PR TITLE
Support WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ For sounds, you need one of: `paplay`, `aplay`, `mpv`, or `ffplay`
 - Only `.wav` files work (not mp3)
 - Use full paths like `C:/Users/You/sounds/alert.wav` not `~/`
 
+**WSL**: It's recommeneded to set `customIconPath` pointing to a file on Windows filesystem
+due to issues with path translation (can be copied from `logos` folder from this repository).
+This path will be passed down to `snoretoast-*.exe`
+
+In `opencode-notifier.json` config:
+```json
+  "showIcon": true,
+  "customIconPath": "C:\\Users\\jhon\\Documents\\opencode-logo-dark.png",
+```
+
+- If notifications are not showing up, check out: (missing WSL notification)[https://github.com/mikaelbr/node-notifier?tab=readme-ov-file#windows-and-wsl2]
+
 ## Config file
 
 Create `~/.config/opencode/opencode-notifier.json` with the defaults:
@@ -55,6 +67,7 @@ Create `~/.config/opencode/opencode-notifier.json` with the defaults:
   "showProjectName": true,
   "showSessionTitle": false,
   "showIcon": true,
+  "customIconPath": null,
   "suppressWhenFocused": true,
   "enableOnDesktop": false,
   "notificationSystem": "osascript",

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import { readFileSync, existsSync } from "fs"
 import { join, dirname } from "path"
 import { homedir } from "os"
 import { fileURLToPath } from "url"
+import isWsl from "is-wsl"
 
 export type EventType = 
   | "permission"
@@ -50,6 +51,7 @@ export interface NotifierConfig {
   showProjectName: boolean
   showSessionTitle: boolean
   showIcon: boolean
+  customIconPath: string | null
   suppressWhenFocused: boolean
   enableOnDesktop: boolean
   notificationSystem: "osascript" | "node-notifier" | "ghostty"
@@ -124,6 +126,7 @@ const DEFAULT_CONFIG: NotifierConfig = {
   showProjectName: true,
   showSessionTitle: false,
   showIcon: true,
+  customIconPath: null,
   suppressWhenFocused: true,
   enableOnDesktop: false,
   notificationSystem: "osascript",
@@ -287,6 +290,7 @@ export function loadConfig(): NotifierConfig {
       showProjectName: userConfig.showProjectName ?? DEFAULT_CONFIG.showProjectName,
       showSessionTitle: userConfig.showSessionTitle ?? DEFAULT_CONFIG.showSessionTitle,
       showIcon: userConfig.showIcon ?? DEFAULT_CONFIG.showIcon,
+      customIconPath: userConfig.customIconPath ?? DEFAULT_CONFIG.customIconPath,
       suppressWhenFocused: userConfig.suppressWhenFocused ?? DEFAULT_CONFIG.suppressWhenFocused,
       enableOnDesktop: typeof userConfig.enableOnDesktop === "boolean" ? userConfig.enableOnDesktop : DEFAULT_CONFIG.enableOnDesktop,
       notificationSystem:
@@ -399,11 +403,20 @@ export function getIconPath(config: NotifierConfig): string | undefined {
   }
 
   try {
-    const __filename = fileURLToPath(import.meta.url)
-    const __dirname = dirname(__filename)
-    const iconPath = join(__dirname, "..", "logos", "opencode-logo-dark.png")
+    let iconPath: string
+    if (config.customIconPath) {
+      iconPath = config.customIconPath
+    } else {
+      const __filename = fileURLToPath(import.meta.url)
+      const __dirname = dirname(__filename)
+      iconPath = join(__dirname, "..", "logos", "opencode-logo-dark.png")
+    }
 
-    if (existsSync(iconPath)) {
+    // Don't check when invoked from WSL since it will
+    // fail to verify windows path anyway (currently
+    // path with backslackes needs to be specified)
+    // https://github.com/mikaelbr/node-notifier/issues/354
+    if (isWsl || existsSync(iconPath)) {
       return iconPath
     }
   } catch {

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -1,6 +1,7 @@
 import os from "os"
 import { exec, execFile } from "child_process"
 import notifier from "node-notifier"
+import isWsl from "is-wsl"
 
 const DEBOUNCE_MS = 1000
 
@@ -8,12 +9,12 @@ const platform = os.type()
 
 let platformNotifier: any
 
-if (platform === "Linux" || platform.match(/BSD$/)) {
-  const { NotifySend } = notifier
-  platformNotifier = new NotifySend({ withFallback: false })
-} else if (platform === "Windows_NT") {
+if (platform === "Windows_NT" || isWsl) {
   const { WindowsToaster } = notifier
   platformNotifier = new WindowsToaster({ withFallback: false })
+} else if (platform === "Linux" || platform.match(/BSD$/)) {
+  const { NotifySend } = notifier
+  platformNotifier = new NotifySend({ withFallback: false })
 } else if (platform !== "Darwin") {
   platformNotifier = notifier
 }
@@ -156,7 +157,7 @@ export async function sendNotification(
     })
   }
 
-  if (platform === "Linux" || platform.match(/BSD$/)) {
+  if ((platform === "Linux" || platform.match(/BSD$/)) && !isWsl) {
     if (linuxGrouping) {
       if (linuxNotifySendSupportsReplace === null) {
         linuxNotifySendSupportsReplace = await detectNotifySendCapabilities()


### PR DESCRIPTION
`node-notifier` has support for WSL but current logic is treating WSL just like Linux which makes notifications not being emitted.

- added check for WSL in order to use Windows `SnoreToaster`,
- allow to configure icon path due to issue with path translation (so icon can be properly shown https://github.com/mikaelbr/node-notifier/issues/354)