### PR TITLE
feat: add KDE notification jump-back action

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ Restart OpenCode. Done.
 ## What it does
 
 You'll get notified when:
+
 - OpenCode needs permission to run something
 - Your session finishes
-- An error happens  
+- An error happens
 - The question tool pops up
 
 There's also `subagent_complete` for when subagents finish, and `user_cancelled` for when you press ESC to abort -- both are silent by default so you don't get spammed.
@@ -39,6 +40,7 @@ sudo pacman -S libnotify         # Arch
 For sounds, you need one of: `paplay`, `aplay`, `mpv`, or `ffplay`
 
 **Windows**: Works out of the box. But heads up:
+
 - Only `.wav` files work (not mp3)
 - Use full paths like `C:/Users/You/sounds/alert.wav` not `~/`
 
@@ -217,7 +219,7 @@ Messages support placeholder tokens that get replaced with actual values:
 - `{timestamp}` - Current time in `HH:MM:SS` format (e.g. "14:30:05")
 - `{turn}` - Global notification counter that persists across restarts (e.g. 1, 2, 3). Stored in `~/.config/opencode/opencode-notifier-state.json`
 
-When `showSessionTitle` is `false`, `{sessionTitle}` is replaced with an empty string. Any trailing separators (`: `, ` - `, ` | `) are automatically cleaned up when a placeholder resolves to empty.
+When `showSessionTitle` is `false`, `{sessionTitle}` is replaced with an empty string. Any trailing separators (`: `, `-`, `|`) are automatically cleaned up when a placeholder resolves to empty.
 
 To disable session titles in messages without changing `showSessionTitle`, just remove the `{sessionTitle}` placeholder from your custom messages.
 
@@ -245,6 +247,7 @@ Use your own sound files:
 ```
 
 Platform notes:
+
 - macOS/Linux: .wav or .mp3 files work
 - Windows: Only .wav files work
 - If file doesn't exist, falls back to bundled sound
@@ -367,17 +370,17 @@ To disable this and always get notified:
 
 ### Platform support
 
-| Platform | Method | Requirements | Status |
-|----------|--------|--------------|--------|
-| macOS | AppleScript (`System Events`) | None | Untested |
-| Linux X11 | `xdotool` | `xdotool` installed | Untested |
-| Linux Wayland (Hyprland) | `hyprctl activewindow` | None | Tested |
-| Linux Wayland (Niri) | `niri msg --json focused-window` | None | Tested |
-| Linux Wayland (Sway) | `swaymsg -t get_tree` | None | Untested |
-| Linux Wayland (KDE) | `kdotool` | `kdotool` installed | Untested |
-| Linux Wayland (GNOME) | Not supported | - | Falls back to always notifying |
-| Linux Wayland (river, dwl, Cosmic, etc.) | Not supported | - | Falls back to always notifying |
-| Windows | `GetForegroundWindow()` via PowerShell | None | Untested |
+| Platform                                 | Method                                   | Requirements          | Status                         |
+| ---------------------------------------- | ---------------------------------------- | --------------------- | ------------------------------ |
+| macOS                                    | AppleScript (`System Events`)          | None                  | Untested                       |
+| Linux X11                                | `xdotool`                              | `xdotool` installed | Untested                       |
+| Linux Wayland (Hyprland)                 | `hyprctl activewindow`                 | None                  | Tested                         |
+| Linux Wayland (Niri)                     | `niri msg --json focused-window`       | None                  | Tested                         |
+| Linux Wayland (Sway)                     | `swaymsg -t get_tree`                  | None                  | Untested                       |
+| Linux Wayland (KDE)                      | `kdotool`                              | `kdotool` installed | Tested                         |
+| Linux Wayland (GNOME)                    | Not supported                            | -                     | Falls back to always notifying |
+| Linux Wayland (river, dwl, Cosmic, etc.) | Not supported                            | -                     | Falls back to always notifying |
+| Windows                                  | `GetForegroundWindow()` via PowerShell | None                  | Untested                       |
 
 **Unsupported compositors**: Wayland has no standard protocol for querying the focused window. Each compositor has its own IPC, and GNOME intentionally doesn't expose focus information. Unsupported compositors fall back to always notifying.
 
@@ -407,6 +410,15 @@ With grouping enabled, each new notification replaces the previous one so you on
 
 Works with all major notification daemons (GNOME, dunst, mako, swaync, etc.) on both X11 and Wayland.
 
+## KDE Plasma: Jump back to terminal from notification
+
+On KDE Plasma/Wayland, clicking the popup body is not consistently delivered as a notification activation event.This plugin uses an explicit notification action button instead:
+
+- **Jump to terminal** (action button on the popup card, or in notification history)
+
+When clicked, the plugin runs its terminal-focus path. On KDE with `kdotool` installed, it auto-captures the startup terminal window ID and jumps back to that pinned window.
+The action button is only enabled on Linux KDE sessions where `kdotool` is available.
+
 ## Updating
 
 If Opencode does not update the plugin or there is an issue with the cache version:
@@ -431,6 +443,7 @@ Switch back to osascript. Some users report node-notifier works for sounds but n
 
 **Linux: No notifications?**
 Install libnotify-bin:
+
 ```bash
 sudo apt install libnotify-bin  # Debian/Ubuntu
 sudo dnf install libnotify       # Fedora
@@ -442,7 +455,39 @@ Test with: `notify-send "Test" "Hello"`
 **Linux: No sounds?**
 Install one of: `paplay`, `aplay`, `mpv`, or `ffplay`
 
+**KDE Plasma: jumps to wrong terminal window or doesn't jump?**
+
+Jump back feature tested on:
+
+- KWin with default floating windows
+- KWin + Krohnkite
+- Ghostty and Konsole
+- Warp
+- OpenCode in tmux inside VS Code terminal
+
+Most terminal emulators should work fine, but there can be exceptions.
+
+Known limitations:
+
+- Kitty is currently unsupported for this jump-back path (unstable focus targeting)
+- Yakuake sessions are not supported for activity-specific jump-back behavior
+
+You can still override manually (if needed) by pinning an explicit window ID:
+
+```bash
+export OPENCODE_NOTIFIER_WINDOW_ID="$(kdotool getactivewindow)"
+opencode
+```
+
+Manual pinning bypasses heuristic window matching and should activate that exact window on notification action click.
+
+**X11 deterministic jump-back**
+
+- `xdotool` support is possible for the same startup pin behavior
+- not implemented yet
+
 **Windows: Custom sounds not working?**
+
 - Must be .wav format (not .mp3)
 - Use full Windows paths: `C:/Users/YourName/sounds/alert.wav` (not `~/`)
 - Make sure the file actually plays in Windows Media Player
@@ -485,6 +530,7 @@ This is a known Bun issue on Windows. Disable native notifications and use Power
 ```
 
 **Plugin not loading?**
+
 - Check your opencode.json syntax
 - Clear the cache (see Updating section)
 - Restart OpenCode

--- a/src/focus.ts
+++ b/src/focus.ts
@@ -1,4 +1,24 @@
-import { execFileSync, execSync } from "child_process"
+import { execFile, execFileSync, execSync } from "child_process"
+
+const LINUX_TERMINAL_APPS = new Set<string>([
+  "ghostty",
+  "konsole",
+  "gnome-terminal",
+  "xterm",
+  "urxvt",
+  "alacritty",
+  "kitty",
+  "wezterm",
+  "wezterm-gui",
+  "tilix",
+  "terminator",
+  "xfce4-terminal",
+  "lxterminal",
+  "mate-terminal",
+  "deepin-terminal",
+  "foot",
+  "footclient",
+])
 
 const MAC_TERMINAL_APP_NAMES = new Set<string>([
   "terminal",
@@ -199,6 +219,10 @@ function getActiveWindowId(): string | null {
 }
 
 const cachedWindowId: string | null = getActiveWindowId()
+const cachedWindowTitle: string | null =
+  process.platform === "linux" && !!process.env.KDE_SESSION_VERSION && cachedWindowId
+    ? getWindowTitleFromKdotool(cachedWindowId)
+    : null
 
 export function isTmuxPaneFocused(tmuxPane: string | null | undefined, probeResult: string | null): boolean {
   if (!tmuxPane) return false
@@ -247,5 +271,454 @@ export function isTerminalFocused(): boolean {
     return true
   } catch {
     return false
+  }
+}
+
+function getWindowIdFromXdotool(searchTerm: string): string | null {
+  return execWithTimeout(`xdotool search --classname "${searchTerm}" | head -1`)
+}
+
+function getWindowIdFromKdotool(searchTerm: string): string | null {
+  return execWithTimeout(`kdotool search --classname "${searchTerm}" | head -1`)
+}
+
+function getWindowTitleFromKdotool(windowId: string): string | null {
+  return execWithTimeout(`kdotool getwindowname ${windowId}`)
+}
+
+let cachedKDEJumpBackSupport: boolean | null = null
+
+export function isKDEJumpBackSupported(): boolean {
+  if (process.platform !== "linux" || !process.env.KDE_SESSION_VERSION) {
+    return false
+  }
+
+  if (cachedKDEJumpBackSupport !== null) {
+    return cachedKDEJumpBackSupport
+  }
+
+  cachedKDEJumpBackSupport = execFileWithTimeout("kdotool", ["--help"], 1000) !== null
+  return cachedKDEJumpBackSupport
+}
+
+function getWindowClassX11(windowId: string): string | null {
+  return execWithTimeout(`xprop -id ${windowId} WM_CLASS 2>/dev/null | awk -F '"' '{print $4}'`)
+}
+
+function getWaylandAppId(windowId: string): string | null {
+  if (process.env.HYPRLAND_INSTANCE_SIGNATURE) {
+    const output = execWithTimeout(`hyprctl clients -j`)
+    if (!output) return null
+    try {
+      const clients = JSON.parse(output)
+      for (const client of clients) {
+        if (String(client.address) === windowId) {
+          return client.class?.toLowerCase() || client.initialClass?.toLowerCase() || null
+        }
+      }
+    } catch {
+      return null
+    }
+  }
+
+  if (process.env.SWAYSOCK) {
+    const output = execWithTimeout(`swaymsg -t get_tree`, 1000)
+    if (!output) return null
+    try {
+      const tree = JSON.parse(output)
+      const findWindow = (node: any): string | null => {
+        if (String(node.id) === windowId) {
+          return node.app_id?.toLowerCase() || node.window_properties?.class?.toLowerCase() || null
+        }
+        if (Array.isArray(node.nodes)) {
+          for (const child of node.nodes) {
+            const result = findWindow(child)
+            if (result) return result
+          }
+        }
+        if (Array.isArray(node.floating_nodes)) {
+          for (const child of node.floating_nodes) {
+            const result = findWindow(child)
+            if (result) return result
+          }
+        }
+        return null
+      }
+      return findWindow(tree)
+    } catch {
+      return null
+    }
+  }
+
+  if (process.env.NIRI_SOCKET) {
+    const output = execWithTimeout(`niri msg --json windows`)
+    if (!output) return null
+    try {
+      const windows = JSON.parse(output)
+      for (const window of windows) {
+        if (String(window.id) === windowId) {
+          return window.app_id?.toLowerCase() || null
+        }
+      }
+    } catch {
+      return null
+    }
+  }
+
+  return null
+}
+
+function getTerminalWindowId(): string | null {
+  if (process.platform !== "linux") return null
+
+  const term = process.env.TERM_PROGRAM?.toLowerCase() || ""
+  const desktopSession = process.env.DESKTOP_SESSION?.toLowerCase() || ""
+  const isKDE = process.env.KDE_SESSION_VERSION || desktopSession.includes("plasma")
+
+  if (process.env.WAYLAND_DISPLAY) {
+    const cachedId = cachedWindowId
+    if (cachedId) {
+      const appId = getWaylandAppId(cachedId)
+      if (appId && LINUX_TERMINAL_APPS.has(appId)) {
+        return cachedId
+      }
+    }
+    // On KDE Wayland, kdotool may not be available, so we rely on KWin scripts
+    if (isKDE) {
+      return cachedId || "kde-wayland"
+    }
+    return cachedId
+  }
+
+  if (process.env.DISPLAY) {
+    const cachedId = cachedWindowId
+    if (cachedId) {
+      const windowClass = getWindowClassX11(cachedId)
+      if (windowClass && LINUX_TERMINAL_APPS.has(windowClass.toLowerCase())) {
+        return cachedId
+      }
+    }
+    for (const app of LINUX_TERMINAL_APPS) {
+      const id = isKDE ? getWindowIdFromKdotool(app) : getWindowIdFromXdotool(app)
+      if (id) return id
+    }
+  }
+
+  return null
+}
+
+function focusLinuxWindowX11(windowId: string): void {
+  try {
+    execSync(`xdotool windowactivate ${windowId} 2>/dev/null`, { timeout: 1000 })
+  } catch {
+  }
+}
+
+function focusLinuxWindowKDE(windowId: string): void {
+  try {
+    const result = execWithTimeout(`kdotool getactivewindow`)
+    if (result === windowId) return
+    execSync(`kdotool windowactivate ${windowId} 2>/dev/null`, { timeout: 1000 })
+  } catch {
+    // kdotool not available, try KWin script approach
+    focusKDEWithKWinScript()
+  }
+}
+
+// Walk up the process tree to find the terminal PID dynamically
+function findTerminalPid(): number {
+  try {
+    let currentPid = process.pid
+    const fs = require("fs")
+    
+    // Walk up the process tree
+    while (currentPid > 1) {
+      try {
+        // Read the parent PID from /proc
+        const statContent = fs.readFileSync(`/proc/${currentPid}/stat`, "utf-8")
+        // Extract parent PID from stat file (field 4)
+        const match = statContent.match(/^\d+\s+\([^)]+\)\s+\S\s+(\d+)/)
+        if (!match) break
+        
+        const ppid = parseInt(match[1], 10)
+        
+        // Read the command name
+        const cmdline = fs.readFileSync(`/proc/${ppid}/comm`, "utf-8").trim()
+        
+        // Check if this looks like a terminal
+        if (cmdline.match(/ghostty|konsole|gnome-terminal|xterm|alacritty|kitty|wezterm|terminator|tilix|foot/i)) {
+          return ppid
+        }
+        
+        currentPid = ppid
+      } catch {
+        break
+      }
+    }
+    
+    // Fallback to PPID if no terminal found
+    return process.ppid
+  } catch {
+    return process.ppid
+  }
+}
+
+function focusKDEWithKWinScript(): void {
+  try {
+    const pinnedWindowId = process.env.OPENCODE_NOTIFIER_WINDOW_ID?.trim() || null
+    if (pinnedWindowId) {
+      try {
+        execSync(`kdotool windowactivate ${pinnedWindowId} 2>/dev/null`, { timeout: 1500 })
+        return
+      } catch {
+      }
+    }
+
+    if (cachedWindowId) {
+      try {
+        execSync(`kdotool windowactivate ${cachedWindowId} 2>/dev/null`, { timeout: 1500 })
+        return
+      } catch {
+      }
+    }
+
+    // Find terminal PID dynamically (OpenCode might be a daemon)
+    const terminalPid = findTerminalPid()
+    const currentPid = process.pid
+    const termProgram = (process.env.TERM_PROGRAM || "terminal").toLowerCase()
+    const cwd = process.cwd().toLowerCase()
+    const cwdBase = cwd.split("/").filter(Boolean).pop() || ""
+    const cachedTitle = (cachedWindowTitle || "").toLowerCase()
+
+    // Create a temporary KWin script
+    const scriptContent = `
+function activateTargetWindow(window) {
+    // Jump to the window's desktop/activity first, then activate.
+    // This works more reliably on Plasma than moving windows between desktops.
+    try {
+        if (window.desktops && window.desktops.length > 0) {
+            workspace.currentDesktop = window.desktops[0];
+        } else if (typeof window.desktop === "number" && window.desktop > 0) {
+            workspace.currentDesktop = window.desktop;
+        }
+    } catch (e) {}
+
+    try {
+        if (window.activities && window.activities.length > 0 && typeof workspace.currentActivity !== "undefined") {
+            workspace.currentActivity = window.activities[0];
+        }
+    } catch (e) {}
+
+    try { window.minimized = false; } catch (e) {}
+
+    try { workspace.activeWindow = window; } catch (e) {}
+    try {
+        if (typeof workspace.activateWindow === "function") {
+            workspace.activateWindow(window);
+        }
+    } catch (e) {}
+    try { window.active = true; } catch (e) {}
+
+    // Nudge stacking so KWin treats this like an explicit user jump.
+    try {
+        window.keepAbove = true;
+        window.keepAbove = false;
+    } catch (e) {}
+}
+
+function isLikelyTerminal(window) {
+    var resourceClass = (window.resourceClass || "").toLowerCase();
+    var resourceName = (window.resourceName || "").toLowerCase();
+    var caption = (window.caption || "").toLowerCase();
+
+    return resourceClass.indexOf("ghostty") !== -1 ||
+           resourceName.indexOf("ghostty") !== -1 ||
+           caption.indexOf("ghostty") !== -1 ||
+           resourceClass.indexOf("konsole") !== -1 ||
+           resourceName.indexOf("konsole") !== -1 ||
+           caption.indexOf("konsole") !== -1 ||
+           resourceClass.indexOf("terminal") !== -1 ||
+           resourceName.indexOf("terminal") !== -1;
+}
+
+function findAndActivateTerminal() {
+    var allWindows = workspace.windowList();
+    var terminalPid = ${terminalPid};
+    var termProgramHint = ${JSON.stringify(termProgram)};
+    var cwdHint = ${JSON.stringify(cwd)};
+    var cwdBaseHint = ${JSON.stringify(cwdBase)};
+    var cachedTitleHint = ${JSON.stringify(cachedTitle)};
+
+    function contains(haystack, needle) {
+        return !!needle && needle.length > 0 && haystack.indexOf(needle) !== -1;
+    }
+
+    function windowScore(window) {
+        var resourceClass = (window.resourceClass || "").toLowerCase();
+        var resourceName = (window.resourceName || "").toLowerCase();
+        var caption = (window.caption || "").toLowerCase();
+        var score = 0;
+
+        if (window.pid === terminalPid) score += 30;
+        if (contains(caption, "opencode")) score += 60;
+        if (contains(caption, cachedTitleHint)) score += 50;
+        if (contains(caption, cwdBaseHint)) score += 35;
+        if (contains(caption, cwdHint)) score += 20;
+        if (contains(resourceClass, termProgramHint) || contains(resourceName, termProgramHint) || contains(caption, termProgramHint)) score += 20;
+        if (isLikelyTerminal(window)) score += 10;
+        if (window.minimized === true) score -= 5;
+
+        return score;
+    }
+
+    var bestWindow = null;
+    var bestScore = -1;
+
+    for (var i = 0; i < allWindows.length; i++) {
+        var candidate = allWindows[i];
+        var score = windowScore(candidate);
+        if (score > bestScore) {
+            bestWindow = candidate;
+            bestScore = score;
+        }
+    }
+
+    // Require enough confidence to avoid jumping to unrelated terminals.
+    if (bestWindow && bestScore >= 30) {
+        activateTargetWindow(bestWindow);
+        return true;
+    }
+
+    return false;
+}
+
+findAndActivateTerminal();
+`;
+    
+    const fs = require("fs");
+    const os = require("os");
+    const path = require("path");
+    
+    const scriptPath = path.join(os.tmpdir(), `opencode-focus-${currentPid}.kwinscript`);
+    const pluginName = `opencode-focus-${currentPid}`;
+    fs.writeFileSync(scriptPath, scriptContent);
+
+    // Load the script
+    execSync(
+      `qdbus org.kde.KWin /Scripting org.kde.kwin.Scripting.loadScript "${scriptPath}" "${pluginName}"`,
+      { encoding: "utf-8", timeout: 2000 }
+    ).trim();
+    
+    // Start the script
+    execSync(
+      `qdbus org.kde.KWin /Scripting org.kde.kwin.Scripting.start`,
+      { timeout: 2000 }
+    );
+    
+    // Clean up
+    try {
+      fs.unlinkSync(scriptPath);
+    } catch {}
+    
+    // Unload the script after a short delay
+    setTimeout(() => {
+      try {
+        execSync(
+          `qdbus org.kde.KWin /Scripting org.kde.kwin.Scripting.unloadScript "${pluginName}"`,
+          { timeout: 500 }
+        );
+      } catch {}
+    }, 1000);
+    
+  } catch {
+    // Fall back to xdotool
+    try {
+      const cachedId = cachedWindowId;
+      if (cachedId) {
+        execSync(`xdotool windowactivate ${cachedId} 2>/dev/null`, { timeout: 1000 });
+      }
+    } catch {}
+  }
+}
+
+function focusLinuxWindowHyprland(windowId: string): void {
+  try {
+    execSync(`hyprctl dispatch focuswindow address:${windowId} 2>/dev/null`, { timeout: 1000 })
+  } catch {
+  }
+}
+
+function focusLinuxWindowSway(windowId: string): void {
+  try {
+    execSync(`swaymsg "[con_id=${windowId}] focus" 2>/dev/null`, { timeout: 1000 })
+  } catch {
+  }
+}
+
+function focusLinuxWindowNiri(windowId: string): void {
+  try {
+    execSync(`niri msg action focus-window --id ${windowId} 2>/dev/null`, { timeout: 1000 })
+  } catch {
+  }
+}
+
+export function captureStartupWindowId(): void {
+  if (!isKDEJumpBackSupported()) {
+    return
+  }
+
+  const existing = process.env.OPENCODE_NOTIFIER_WINDOW_ID?.trim()
+  if (existing) {
+    return
+  }
+
+  const detected = execWithTimeout("kdotool getactivewindow", 1000)
+  if (detected && /^\d+$/.test(detected)) {
+    process.env.OPENCODE_NOTIFIER_WINDOW_ID = detected
+  }
+}
+
+export async function focusTerminal(): Promise<void> {
+  if (process.platform === "darwin") {
+    try {
+      const frontmostAppName = getMacOSFrontmostAppName()
+      if (frontmostAppName && isMacTerminalAppFocused(frontmostAppName, process.env)) {
+        return
+      }
+      const expectedApps = getExpectedMacTerminalAppNames(process.env)
+      for (const app of expectedApps) {
+        try {
+          execSync(`osascript -e 'tell application "${app}" to activate' 2>/dev/null`, { timeout: 1000 })
+          return
+        } catch {
+        }
+      }
+      execSync(`osascript -e 'tell application "Terminal" to activate' 2>/dev/null`, { timeout: 1000 })
+    } catch {
+    }
+    return
+  }
+
+  if (process.platform === "linux") {
+    const env = process.env
+    
+    // For KDE Plasma, use KWin script approach which works on both X11 and Wayland
+    if (env.KDE_SESSION_VERSION) {
+      focusKDEWithKWinScript()
+      return
+    }
+    
+    const windowId = getTerminalWindowId()
+    if (!windowId) return
+
+    if (env.HYPRLAND_INSTANCE_SIGNATURE) {
+      focusLinuxWindowHyprland(windowId)
+    } else if (env.SWAYSOCK) {
+      focusLinuxWindowSway(windowId)
+    } else if (env.NIRI_SOCKET) {
+      focusLinuxWindowNiri(windowId)
+    } else if (env.DISPLAY) {
+      focusLinuxWindowX11(windowId)
+    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import { sendNotification } from "./notify"
 import { playSound } from "./sound"
 import { ringBell } from "./bell"
 import { runCommand } from "./command"
-import { isTerminalFocused } from "./focus"
+import { isTerminalFocused, focusTerminal, captureStartupWindowId, isKDEJumpBackSupported } from "./focus"
 import { shouldSuppressPermissionAlert, prunePermissionAlertState } from "./permission-dedupe"
 
 const IDLE_COMPLETE_DELAY_MS = 350
@@ -185,7 +185,8 @@ async function handleEvent(
   if (isEventNotificationEnabled(config, eventType)) {
     const title = getNotificationTitle(config, projectName)
     const iconPath = getIconPath(config)
-    promises.push(sendNotification(title, message, config.timeout, iconPath, config.notificationSystem, config.linux.grouping))
+    const onNotificationClick = isKDEJumpBackSupported() ? () => void focusTerminal() : undefined
+    promises.push(sendNotification(title, message, config.timeout, iconPath, config.notificationSystem, config.linux.grouping, onNotificationClick))
   }
 
   if (isEventSoundEnabled(config, eventType)) {
@@ -455,6 +456,8 @@ async function handleEventWithElapsedTime(
 }
 
 export const NotifierPlugin: Plugin = async ({ client, directory }) => {
+  captureStartupWindowId()
+
   const clientEnv = process.env.OPENCODE_CLIENT
   if (clientEnv && clientEnv !== "cli") {
     const config = loadConfig()

--- a/src/notify.test.ts
+++ b/src/notify.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test"
-import { formatGhosttyNotificationSequence } from "./notify"
+import { formatGhosttyNotificationSequence, parseNotifySendOutputLine } from "./notify"
 
 describe("formatGhosttyNotificationSequence", () => {
   test("returns plain OSC 9 outside tmux", () => {
@@ -15,5 +15,26 @@ describe("formatGhosttyNotificationSequence", () => {
   test("sanitizes forbidden control characters", () => {
     const sequence = formatGhosttyNotificationSequence("A;B", "C\nD\x07E\x1bF\r", {})
     expect(sequence).toBe("\x1b]9;AB: CDEF\x07")
+  })
+})
+
+describe("parseNotifySendOutputLine", () => {
+  test("parses notification id lines", () => {
+    expect(parseNotifySendOutputLine("12345")).toEqual({ type: "id", id: 12345 })
+  })
+
+  test("parses focus action key", () => {
+    expect(parseNotifySendOutputLine("focus-terminal")).toEqual({ type: "action", action: "focus" })
+  })
+
+  test("parses close action", () => {
+    expect(parseNotifySendOutputLine("close")).toEqual({ type: "action", action: "close" })
+  })
+
+  test("ignores legacy/default tokens and unknown values", () => {
+    expect(parseNotifySendOutputLine("default")).toBeNull()
+    expect(parseNotifySendOutputLine("0")).toEqual({ type: "id", id: 0 })
+    expect(parseNotifySendOutputLine("Focus")).toBeNull()
+    expect(parseNotifySendOutputLine("random")).toBeNull()
   })
 })

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -1,5 +1,5 @@
 import os from "os"
-import { exec, execFile } from "child_process"
+import { exec, execFile, spawn } from "child_process"
 import notifier from "node-notifier"
 
 const DEBOUNCE_MS = 1000
@@ -17,6 +17,11 @@ if (platform === "Linux" || platform.match(/BSD$/)) {
 } else if (platform !== "Darwin") {
   platformNotifier = notifier
 }
+
+export type NotificationAction = "focus" | "close"
+
+const LINUX_FOCUS_ACTION_KEY = "focus-terminal"
+const LINUX_FOCUS_ACTION_LABEL = "Jump to terminal"
 
 const lastNotificationTime: Record<string, number> = {}
 
@@ -67,9 +72,17 @@ function sendLinuxNotificationDirect(
   message: string,
   timeout: number,
   iconPath?: string,
-  grouping: boolean = true
+  grouping: boolean = true,
+  onAction?: (action: NotificationAction) => void
 ): Promise<void> {
   return new Promise((resolve) => {
+    if (onAction) {
+      sendLinuxNotificationWithActions(title, message, timeout, iconPath, grouping, onAction)
+        .then(() => resolve())
+        .catch(() => resolve())
+      return
+    }
+
     const args: string[] = []
 
     args.push("--app-name", "opencode")
@@ -102,13 +115,126 @@ function sendLinuxNotificationDirect(
   })
 }
 
+async function sendLinuxNotificationWithActions(
+  title: string,
+  message: string,
+  timeout: number,
+  iconPath?: string,
+  grouping: boolean = true,
+  onAction?: (action: NotificationAction) => void
+): Promise<void> {
+  const args: string[] = ["--app-name", "opencode"]
+
+  if (iconPath) {
+    args.push("--icon", iconPath)
+  }
+
+  args.push("--expire-time", String(timeout * 1000))
+
+  if (grouping && lastLinuxNotificationId !== null) {
+    args.push("--replace-id", String(lastLinuxNotificationId))
+  }
+
+  // Always print ID so we can resolve early (before user clicks)
+  // and still keep replace-id working.
+  args.push("--print-id")
+
+  args.push("--action", `${LINUX_FOCUS_ACTION_KEY}=${LINUX_FOCUS_ACTION_LABEL}`)
+
+  args.push("--", title, message)
+
+  return new Promise((resolve) => {
+    const child = spawn("notify-send", args, { stdio: ["ignore", "pipe", "pipe"] })
+
+    let stdout = ""
+
+    const consumeStdout = () => {
+      const lines = stdout.split(/\r?\n/)
+      // Keep the last partial line buffered.
+      stdout = lines.pop() ?? ""
+
+      for (const rawLine of lines) {
+        const line = rawLine.trim()
+        if (!line) {
+          continue
+        }
+
+        const parsed = parseNotifySendOutputLine(line)
+        if (!parsed) {
+          continue
+        }
+
+        if (parsed.type === "id") {
+          if (grouping) {
+            lastLinuxNotificationId = parsed.id
+          }
+          continue
+        }
+
+        if (onAction) {
+          if (parsed.action === "focus") {
+            onAction("focus")
+          } else if (parsed.action === "close") {
+            onAction("close")
+          }
+        }
+      }
+    }
+
+    child.stdout?.on("data", (data) => {
+      stdout += data.toString()
+      consumeStdout()
+    })
+
+    child.on("close", () => {
+      // Flush any remaining buffered stdout when process exits.
+      if (stdout.trim().length > 0) {
+        stdout += "\n"
+        consumeStdout()
+      }
+      resolve()
+    })
+
+    child.on("error", () => {
+      resolve()
+    })
+  })
+}
+
+export function parseNotifySendOutputLine(
+  line: string
+): { type: "id"; id: number } | { type: "action"; action: NotificationAction } | null {
+  const trimmed = line.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  if (/^\d+$/.test(trimmed)) {
+    const id = parseInt(trimmed, 10)
+    if (!isNaN(id)) {
+      return { type: "id", id }
+    }
+  }
+
+  if (trimmed === LINUX_FOCUS_ACTION_KEY) {
+    return { type: "action", action: "focus" }
+  }
+
+  if (trimmed === "close") {
+    return { type: "action", action: "close" }
+  }
+
+  return null
+}
+
 export async function sendNotification(
   title: string,
   message: string,
   timeout: number,
   iconPath?: string,
   notificationSystem: "osascript" | "node-notifier" | "ghostty" = "osascript",
-  linuxGrouping: boolean = true
+  linuxGrouping: boolean = true,
+  onClick?: () => void
 ): Promise<void> {
   const now = Date.now()
   if (lastNotificationTime[message] && now - lastNotificationTime[message] < DEBOUNCE_MS) {
@@ -157,6 +283,21 @@ export async function sendNotification(
   }
 
   if (platform === "Linux" || platform.match(/BSD$/)) {
+    if (onClick) {
+      if (linuxGrouping) {
+        if (linuxNotifySendSupportsReplace === null) {
+          linuxNotifySendSupportsReplace = await detectNotifySendCapabilities()
+        }
+        if (linuxNotifySendSupportsReplace) {
+          return sendLinuxNotificationDirect(title, message, timeout, iconPath, true, () => onClick())
+        }
+      }
+
+      // Fallback without grouping so action click still works
+      // even when --replace-id is unavailable or disabled.
+      return sendLinuxNotificationDirect(title, message, timeout, iconPath, false, () => onClick())
+    }
+
     if (linuxGrouping) {
       if (linuxNotifySendSupportsReplace === null) {
         linuxNotifySendSupportsReplace = await detectNotifySendCapabilities()
@@ -178,7 +319,10 @@ export async function sendNotification(
 
     platformNotifier.notify(
       notificationOptions,
-      () => {
+      (err: any, response: any, metadata: any) => {
+        if (onClick && metadata?.activationType === "default") {
+          onClick()
+        }
         resolve()
       }
     )


### PR DESCRIPTION
Implement click-to-focus jump-back for KDE Plasma notifications using notify-send actions and KWin/kdotool focus routing.
- Add Linux action-token parsing for notify-send (focus-terminal)
- Wire notification action click to focusTerminal only on KDE+kdotool
- Add startup window-id capture for deterministic jump-back
- Keep manual OPENCODE_NOTIFIER_WINDOW_ID override
-  Document KDE behavior, limitations, and scope in README

implemetation of #66 