### PR TITLE
fix(focus): fall back to tmux pane state

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ To disable this and always get notified:
 
 **Unsupported compositors**: Wayland has no standard protocol for querying the focused window. Each compositor has its own IPC, and GNOME intentionally doesn't expose focus information. Unsupported compositors fall back to always notifying.
 
-**tmux/screen**: When running inside tmux, focus detection uses tmux pane state (`session_attached`, `window_active`, `pane_active`) via `tmux display-message`. This keeps suppression accurate when switching panes/windows/sessions. GNU Screen is not currently handled (falls back to always notifying).
+**tmux/screen**: When running inside tmux, focus detection uses tmux pane state (`session_attached`, `window_active`, `pane_active`) via `tmux display-message`. This keeps suppression accurate when switching panes/windows/sessions. On Linux setups where window focus cannot be detected at all, tmux pane state is also used as a best-effort fallback. GNU Screen is not currently handled (falls back to always notifying).
 
 **WezTerm panes**: When running in WezTerm with `WEZTERM_PANE` set, focus suppression is pane-aware via `wezterm cli list-clients --format json`. This means notifications are shown when you switch to a different WezTerm pane/tab.
 

--- a/src/focus.test.ts
+++ b/src/focus.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test"
-import { isMacTerminalAppFocused, isTmuxPaneFocused, parseWezTermFocusedPaneId } from "./focus"
+import { isLinuxTerminalFocused, isMacTerminalAppFocused, isTmuxPaneFocused, parseWezTermFocusedPaneId } from "./focus"
 
 describe("isMacTerminalAppFocused", () => {
   test("matches Terminal when TERM_PROGRAM is Apple_Terminal", () => {
@@ -72,6 +72,52 @@ describe("isTmuxPaneFocused", () => {
     expect(isTmuxPaneFocused("%1", "1 1 0")).toBe(false)
     expect(isTmuxPaneFocused("%1", "1 0 1")).toBe(false)
     expect(isTmuxPaneFocused("%1", "0 1 1")).toBe(false)
+  })
+})
+
+describe("isLinuxTerminalFocused", () => {
+  test("falls back to tmux pane state when window id is unavailable", () => {
+    expect(
+      isLinuxTerminalFocused({
+        cachedWindowId: null,
+        currentWindowId: null,
+        wezTermPaneActive: true,
+        tmuxPaneActive: true,
+      })
+    ).toBe(true)
+  })
+
+  test("does not suppress without tmux when window id is unavailable", () => {
+    expect(
+      isLinuxTerminalFocused({
+        cachedWindowId: null,
+        currentWindowId: null,
+        wezTermPaneActive: true,
+        tmuxPaneActive: null,
+      })
+    ).toBe(false)
+  })
+
+  test("does not suppress when wezterm pane is inactive", () => {
+    expect(
+      isLinuxTerminalFocused({
+        cachedWindowId: null,
+        currentWindowId: null,
+        wezTermPaneActive: false,
+        tmuxPaneActive: true,
+      })
+    ).toBe(false)
+  })
+
+  test("keeps existing window-id check when available", () => {
+    expect(
+      isLinuxTerminalFocused({
+        cachedWindowId: "123",
+        currentWindowId: "456",
+        wezTermPaneActive: true,
+        tmuxPaneActive: true,
+      })
+    ).toBe(false)
   })
 })
 

--- a/src/focus.ts
+++ b/src/focus.ts
@@ -207,6 +207,26 @@ export function isTmuxPaneFocused(tmuxPane: string | null | undefined, probeResu
   return sessionAttached === "1" && windowActive === "1" && paneActive === "1"
 }
 
+export function isLinuxTerminalFocused(params: {
+  cachedWindowId: string | null
+  currentWindowId: string | null
+  wezTermPaneActive: boolean
+  tmuxPaneActive: boolean | null
+}): boolean {
+  const { cachedWindowId, currentWindowId, wezTermPaneActive, tmuxPaneActive } = params
+
+  if (!cachedWindowId) {
+    if (!wezTermPaneActive) return false
+    if (tmuxPaneActive !== null) return tmuxPaneActive
+    return false
+  }
+
+  if (currentWindowId !== cachedWindowId) return false
+  if (!wezTermPaneActive) return false
+  if (tmuxPaneActive !== null) return tmuxPaneActive
+  return true
+}
+
 function isTmuxPaneActive(): boolean {
   const tmuxPane = process.env.TMUX_PANE ?? null
   const result = execFileWithTimeout("tmux", ["display-message", "-t", tmuxPane ?? "", "-p", "#{session_attached} #{window_active} #{pane_active}"])
@@ -239,12 +259,13 @@ export function isTerminalFocused(): boolean {
       return true
     }
 
-    if (!cachedWindowId) return false
-    const currentId = getActiveWindowId()
-    if (currentId !== cachedWindowId) return false
-    if (!isWezTermPaneActive()) return false
-    if (process.env.TMUX) return isTmuxPaneActive()
-    return true
+    const tmuxPaneActive = process.env.TMUX ? isTmuxPaneActive() : null
+    return isLinuxTerminalFocused({
+      cachedWindowId,
+      currentWindowId: getActiveWindowId(),
+      wezTermPaneActive: isWezTermPaneActive(),
+      tmuxPaneActive,
+    })
   } catch {
     return false
   }


### PR DESCRIPTION
## Summary
- add a Linux focus helper so tmux pane state can be used as a best-effort fallback when no window id is available
- preserve the existing window-id path when compositor focus detection works, and document the fallback in the README
- add focused tests for the new fallback behavior

## Why
On my setup, `suppressWhenFocused` stayed ineffective even after enabling it because Linux window focus detection returned `null` before tmux state was consulted.

## Tested setup where this works
- OS: Linux
- Session type: Wayland
- Desktop: GNOME
- Terminal: Ghostty
- Multiplexer: tmux
- OpenCode notifier version: 0.2.2

With this patch, notifications are suppressed while the current tmux pane is active, which matches the practical expectation for my setup.

## Notes
- This is intentionally a best-effort fallback, not a claim of full GNOME Wayland frontmost-window support.
- I could not run `bun test` locally in this environment because `bun` is not installed here.