### PR TITLE
feat: Add option to show full absolute path for {projectName}

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Create `~/.config/opencode/opencode-notifier.json` with the defaults:
   "bell": false,
   "timeout": 5,
   "showProjectName": true,
+  "showFullPath": false,
   "showSessionTitle": false,
   "showIcon": true,
   "customIconPath": null,
@@ -145,6 +146,7 @@ Create `~/.config/opencode/opencode-notifier.json` with the defaults:
   "bell": false,
   "timeout": 5,
   "showProjectName": true,
+  "showFullPath": false,
   "showSessionTitle": false,
   "showIcon": true,
   "suppressWhenFocused": true,
@@ -158,6 +160,7 @@ Create `~/.config/opencode/opencode-notifier.json` with the defaults:
 - `bell` - Emit terminal BEL (`\x07`) on events (default: false). Behavior depends on your terminal/WM settings
 - `timeout` - How long notifications show in seconds, Linux only (default: 5)
 - `showProjectName` - Show folder name in notification title (default: true)
+- `showFullPath` - Show full absolute path instead of folder name in notification title and `{projectName}` token (default: false). When true, shows `OpenCode (/home/user/projects/myapp)` instead of `OpenCode (myapp)`
 - `showSessionTitle` - Include the session title in notification messages via `{sessionTitle}` placeholder (default: false)
 - `showIcon` - Show OpenCode icon, Windows/Linux only (default: true)
 - `customIconPath` - Path to a custom icon for notifications. Useful on WSL where Windows paths are needed (default: null)

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@mohak34/opencode-notifier",

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,6 +49,7 @@ export interface NotifierConfig {
   bell: boolean
   timeout: number
   showProjectName: boolean
+  showFullPath: boolean
   showSessionTitle: boolean
   showIcon: boolean
   customIconPath: string | null
@@ -125,6 +126,7 @@ const DEFAULT_CONFIG: NotifierConfig = {
   bell: false,
   timeout: 5,
   showProjectName: true,
+  showFullPath: false,
   showSessionTitle: false,
   showIcon: true,
   customIconPath: null,
@@ -290,6 +292,7 @@ export function loadConfig(): NotifierConfig {
           ? userConfig.timeout
           : DEFAULT_CONFIG.timeout,
       showProjectName: userConfig.showProjectName ?? DEFAULT_CONFIG.showProjectName,
+      showFullPath: userConfig.showFullPath ?? DEFAULT_CONFIG.showFullPath,
       showSessionTitle: userConfig.showSessionTitle ?? DEFAULT_CONFIG.showSessionTitle,
       showIcon: userConfig.showIcon ?? DEFAULT_CONFIG.showIcon,
       customIconPath: userConfig.customIconPath ?? DEFAULT_CONFIG.customIconPath,

--- a/src/index.ts
+++ b/src/index.ts
@@ -481,7 +481,7 @@ export const NotifierPlugin: Plugin = async ({ client, directory }) => {
   }
 
   const getConfig = () => loadConfig()
-  const projectName = directory ? basename(directory) : null
+  const projectName = directory ? (getConfig().showFullPath ? directory : basename(directory)) : null
 
   // Fire client_connected after the plugin is fully initialized.
   // There is no SDK event that reliably signals client connection from a plugin's


### PR DESCRIPTION
Currently `{projectName}` in notification titles only shows the folder name (via `basename(directory)`). When working on multiple projects with the same folder name (e.g. multiple `src` or `app` directories), notifications are ambiguous.
### Proposed solution
Add a config option like `showFullPath: true` that makes `{projectName}` and the notification title display the full absolute path instead of just the basename.

```json
{
  "showProjectName": true,
  "showFullPath": true
}
```
Expected result: OpenCode (/home/user/projects/myapp) instead of OpenCode (myapp).
