### PR TITLE
feat: add external notification channels (Gotify, Telegram)

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,61 @@ Run your own script when something happens. Use `{event}`, `{message}`, `{sessio
 }
 ```
 
+### External notification channels
+
+Send notifications to external services such as Gotify or Telegram. Channels are defined in the `externalChannels` array. By default the array is empty and no external notifications are sent.
+
+The notification content (title and message) mirrors what is shown in desktop notifications, including the session name and interruption reason.
+
+#### Gotify
+
+```json
+{
+  "externalChannels": [
+    {
+      "type": "gotify",
+      "url": "https://gotify.example.com",
+      "token": "your-app-token",
+      "priority": 5
+    }
+  ]
+}
+```
+
+- `url` - Base URL of your Gotify server
+- `token` - Application token created in the Gotify UI
+- `priority` - Message priority (optional, default `5`)
+
+#### Telegram
+
+```json
+{
+  "externalChannels": [
+    {
+      "type": "telegram",
+      "token": "123456:ABC-yourBotToken",
+      "chatId": "your-chat-id"
+    }
+  ]
+}
+```
+
+- `token` - Bot API token from [@BotFather](https://t.me/BotFather)
+- `chatId` - Chat, group, or channel ID to send messages to (find it with [@userinfobot](https://t.me/userinfobot))
+
+You can combine multiple channels of the same or different types:
+
+```json
+{
+  "externalChannels": [
+    { "type": "gotify", "url": "https://gotify.example.com", "token": "tok1" },
+    { "type": "telegram", "token": "123:abc", "chatId": "-100123456" }
+  ]
+}
+```
+
+Each channel is sent to in parallel. A failure in one channel is logged to stderr and does not affect the others.
+
 ## macOS: Pick your notification style
 
 **osascript** (default): Reliable but shows Script Editor icon

--- a/README.md
+++ b/README.md
@@ -431,6 +431,8 @@ tmux source-file ~/.tmux.conf
 
 When `suppressWhenFocused` is `true` (the default), notifications and sounds are skipped if the terminal running OpenCode is the active/focused window. The idea is simple: if you're already looking at it, you don't need an alert.
 
+This suppression also applies to external channels (Gotify, Telegram). If you want external channels to always fire even when the terminal is focused, set `suppressWhenFocused` to `false`:
+
 To disable this and always get notified:
 
 ```json

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@mohak34/opencode-notifier",

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -185,13 +185,36 @@ describe("Config", () => {
   })
 
   test("loadConfig defaults new high-frequency events to sound only", async () => {
-    const { loadConfig, isEventSoundEnabled, isEventNotificationEnabled } = await import("./config")
+    const { loadConfig, isEventSoundEnabled, isEventNotificationEnabled, isEventExternalNotificationEnabled } = await import("./config")
     const config = loadConfig()
 
     expect(isEventSoundEnabled(config, "session_started")).toBe(true)
     expect(isEventNotificationEnabled(config, "session_started")).toBe(false)
+    expect(isEventExternalNotificationEnabled(config, "session_started")).toBe(false)
     expect(isEventSoundEnabled(config, "user_message")).toBe(true)
     expect(isEventNotificationEnabled(config, "user_message")).toBe(false)
+    expect(isEventExternalNotificationEnabled(config, "user_message")).toBe(false)
+    expect(isEventExternalNotificationEnabled(config, "client_connected")).toBe(false)
+    expect(isEventExternalNotificationEnabled(config, "user_cancelled")).toBe(false)
+    expect(isEventExternalNotificationEnabled(config, "subagent_complete")).toBe(false)
+  })
+
+  test("loadConfig defaults actionable events to externalNotification enabled", async () => {
+    const { loadConfig, isEventExternalNotificationEnabled } = await import("./config")
+    const config = loadConfig()
+
+    expect(isEventExternalNotificationEnabled(config, "permission")).toBe(true)
+    expect(isEventExternalNotificationEnabled(config, "complete")).toBe(true)
+    expect(isEventExternalNotificationEnabled(config, "error")).toBe(true)
+    expect(isEventExternalNotificationEnabled(config, "question")).toBe(true)
+    expect(isEventExternalNotificationEnabled(config, "interrupted")).toBe(true)
+    expect(isEventExternalNotificationEnabled(config, "plan_exit")).toBe(true)
+  })
+
+  test("loadConfig defaults high-frequency events to sound only (client_connected)", async () => {
+    const { loadConfig, isEventSoundEnabled, isEventNotificationEnabled } = await import("./config")
+    const config = loadConfig()
+
     expect(isEventSoundEnabled(config, "client_connected")).toBe(true)
     expect(isEventNotificationEnabled(config, "client_connected")).toBe(false)
   })

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ import { join, dirname } from "path"
 import { homedir } from "os"
 import { fileURLToPath } from "url"
 import isWsl from "is-wsl"
+import type { ExternalChannelConfig } from "./external-notify"
 
 export type EventType = 
   | "permission"
@@ -58,6 +59,8 @@ export interface NotifierConfig {
   linux: LinuxConfig
   minDuration: number
   command: CommandConfig
+  /** External notification channels (Gotify, Telegram, etc.). Default: [] */
+  externalChannels: ExternalChannelConfig[]
   events: {
     permission: EventConfig
     complete: EventConfig
@@ -140,6 +143,7 @@ const DEFAULT_CONFIG: NotifierConfig = {
     path: "",
     minDuration: 0,
   },
+  externalChannels: [],
   events: {
     permission: { ...DEFAULT_EVENT_CONFIG },
     complete: { ...DEFAULT_EVENT_CONFIG },
@@ -247,6 +251,41 @@ function parseVolume(value: unknown, defaultVolume: number): number {
   return value
 }
 
+function parseExternalChannels(raw: unknown): ExternalChannelConfig[] {
+  if (!Array.isArray(raw)) {
+    return []
+  }
+
+  const result: ExternalChannelConfig[] = []
+  for (const item of raw) {
+    if (item === null || typeof item !== "object") {
+      continue
+    }
+    const ch = item as Record<string, unknown>
+
+    if (ch.type === "gotify") {
+      if (typeof ch.url !== "string" || ch.url.length === 0) continue
+      if (typeof ch.token !== "string" || ch.token.length === 0) continue
+      result.push({
+        type: "gotify",
+        url: ch.url,
+        token: ch.token,
+        priority: typeof ch.priority === "number" ? ch.priority : undefined,
+      })
+    } else if (ch.type === "telegram") {
+      if (typeof ch.token !== "string" || ch.token.length === 0) continue
+      if (typeof ch.chatId !== "string" && typeof ch.chatId !== "number") continue
+      result.push({
+        type: "telegram",
+        token: ch.token,
+        chatId: ch.chatId as string | number,
+      })
+    }
+  }
+
+  return result
+}
+
 export function loadConfig(): NotifierConfig {
   const configPath = getConfigPath()
 
@@ -314,6 +353,7 @@ export function loadConfig(): NotifierConfig {
         args: commandArgs,
         minDuration: commandMinDuration,
       },
+      externalChannels: parseExternalChannels(userConfig.externalChannels),
       events: {
         permission: parseEventConfig(userConfig.events?.permission ?? userConfig.permission, defaultWithGlobal),
         complete: parseEventConfig(userConfig.events?.complete ?? userConfig.complete, defaultWithGlobal),

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,8 @@ export interface EventConfig {
   notification: boolean
   command: boolean
   bell: boolean
+  /** Send to external channels (Gotify, Telegram, etc.). Default: true for most events. */
+  externalNotification: boolean
 }
 
 export interface CommandConfig {
@@ -120,6 +122,7 @@ const DEFAULT_EVENT_CONFIG: EventConfig = {
   notification: true,
   command: true,
   bell: false,
+  externalNotification: true,
 }
 
 const DEFAULT_CONFIG: NotifierConfig = {
@@ -147,15 +150,15 @@ const DEFAULT_CONFIG: NotifierConfig = {
   events: {
     permission: { ...DEFAULT_EVENT_CONFIG },
     complete: { ...DEFAULT_EVENT_CONFIG },
-    subagent_complete: { ...DEFAULT_EVENT_CONFIG, sound: false, notification: false },
+    subagent_complete: { ...DEFAULT_EVENT_CONFIG, sound: false, notification: false, externalNotification: false },
     error: { ...DEFAULT_EVENT_CONFIG },
     question: { ...DEFAULT_EVENT_CONFIG },
     interrupted: { ...DEFAULT_EVENT_CONFIG },
-    user_cancelled: { ...DEFAULT_EVENT_CONFIG, sound: false, notification: false },
+    user_cancelled: { ...DEFAULT_EVENT_CONFIG, sound: false, notification: false, externalNotification: false },
     plan_exit: { ...DEFAULT_EVENT_CONFIG },
-    session_started: { ...DEFAULT_EVENT_CONFIG, notification: false },
-    user_message: { ...DEFAULT_EVENT_CONFIG, notification: false },
-    client_connected: { ...DEFAULT_EVENT_CONFIG, notification: false },
+    session_started: { ...DEFAULT_EVENT_CONFIG, notification: false, externalNotification: false },
+    user_message: { ...DEFAULT_EVENT_CONFIG, notification: false, externalNotification: false },
+    client_connected: { ...DEFAULT_EVENT_CONFIG, notification: false, externalNotification: false },
   },
   messages: {
     permission: "Session needs permission: {sessionTitle}",
@@ -211,7 +214,7 @@ export function getStatePath(): string {
 }
 
 function parseEventConfig(
-  userEvent: boolean | { sound?: boolean; notification?: boolean; command?: boolean; bell?: boolean } | undefined,
+  userEvent: boolean | { sound?: boolean; notification?: boolean; command?: boolean; bell?: boolean; externalNotification?: boolean } | undefined,
   defaultConfig: EventConfig
 ): EventConfig {
   if (userEvent === undefined) {
@@ -224,6 +227,7 @@ function parseEventConfig(
       notification: userEvent,
       command: userEvent,
       bell: defaultConfig.bell,
+      externalNotification: userEvent,
     }
   }
 
@@ -232,6 +236,7 @@ function parseEventConfig(
     notification: userEvent.notification ?? defaultConfig.notification,
     command: userEvent.command ?? defaultConfig.command,
     bell: userEvent.bell ?? defaultConfig.bell,
+    externalNotification: userEvent.externalNotification ?? defaultConfig.externalNotification,
   }
 }
 
@@ -306,6 +311,7 @@ export function loadConfig(): NotifierConfig {
       notification: globalNotification,
       command: true,
       bell: globalBell,
+      externalNotification: true,
     }
 
     const userCommand = userConfig.command ?? {}
@@ -357,15 +363,15 @@ export function loadConfig(): NotifierConfig {
       events: {
         permission: parseEventConfig(userConfig.events?.permission ?? userConfig.permission, defaultWithGlobal),
         complete: parseEventConfig(userConfig.events?.complete ?? userConfig.complete, defaultWithGlobal),
-        subagent_complete: parseEventConfig(userConfig.events?.subagent_complete ?? userConfig.subagent_complete, { sound: false, notification: false, command: true, bell: false }),
+        subagent_complete: parseEventConfig(userConfig.events?.subagent_complete ?? userConfig.subagent_complete, { sound: false, notification: false, command: true, bell: false, externalNotification: false }),
         error: parseEventConfig(userConfig.events?.error ?? userConfig.error, defaultWithGlobal),
         question: parseEventConfig(userConfig.events?.question ?? userConfig.question, defaultWithGlobal),
         interrupted: parseEventConfig(userConfig.events?.interrupted ?? userConfig.interrupted, defaultWithGlobal),
-        user_cancelled: parseEventConfig(userConfig.events?.user_cancelled ?? userConfig.user_cancelled, { sound: false, notification: false, command: true, bell: false }),
+        user_cancelled: parseEventConfig(userConfig.events?.user_cancelled ?? userConfig.user_cancelled, { sound: false, notification: false, command: true, bell: false, externalNotification: false }),
         plan_exit: parseEventConfig(userConfig.events?.plan_exit ?? userConfig.plan_exit, defaultWithGlobal),
-        session_started: parseEventConfig(userConfig.events?.session_started ?? userConfig.session_started, { ...defaultWithGlobal, notification: false }),
-        user_message: parseEventConfig(userConfig.events?.user_message ?? userConfig.user_message, { ...defaultWithGlobal, notification: false }),
-        client_connected: parseEventConfig(userConfig.events?.client_connected ?? userConfig.client_connected, { ...defaultWithGlobal, notification: false }),
+        session_started: parseEventConfig(userConfig.events?.session_started ?? userConfig.session_started, { ...defaultWithGlobal, notification: false, externalNotification: false }),
+        user_message: parseEventConfig(userConfig.events?.user_message ?? userConfig.user_message, { ...defaultWithGlobal, notification: false, externalNotification: false }),
+        client_connected: parseEventConfig(userConfig.events?.client_connected ?? userConfig.client_connected, { ...defaultWithGlobal, notification: false, externalNotification: false }),
       },
       messages: {
         permission: userConfig.messages?.permission ?? DEFAULT_CONFIG.messages.permission,
@@ -429,6 +435,10 @@ export function isEventCommandEnabled(config: NotifierConfig, event: EventType):
 
 export function isEventBellEnabled(config: NotifierConfig, event: EventType): boolean {
   return config.events[event].bell
+}
+
+export function isEventExternalNotificationEnabled(config: NotifierConfig, event: EventType): boolean {
+  return config.events[event].externalNotification
 }
 
 export function getMessage(config: NotifierConfig, event: EventType): string {

--- a/src/external-notify.test.ts
+++ b/src/external-notify.test.ts
@@ -1,0 +1,221 @@
+import { describe, test, expect, mock, beforeEach, afterEach, spyOn } from "bun:test"
+import {
+  escapeMarkdownV2,
+  sendToChannel,
+  sendExternalNotifications,
+} from "./external-notify"
+import type { GotifyChannelConfig, TelegramChannelConfig } from "./external-notify"
+
+// ---------------------------------------------------------------------------
+// escapeMarkdownV2
+// ---------------------------------------------------------------------------
+describe("escapeMarkdownV2", () => {
+  test("leaves plain text untouched", () => {
+    expect(escapeMarkdownV2("Hello world")).toBe("Hello world")
+  })
+
+  test("escapes underscore", () => {
+    expect(escapeMarkdownV2("hello_world")).toBe("hello\\_world")
+  })
+
+  test("escapes asterisk", () => {
+    expect(escapeMarkdownV2("a*b")).toBe("a\\*b")
+  })
+
+  test("escapes parentheses", () => {
+    expect(escapeMarkdownV2("(test)")).toBe("\\(test\\)")
+  })
+
+  test("escapes dot", () => {
+    expect(escapeMarkdownV2("v1.0")).toBe("v1\\.0")
+  })
+
+  test("escapes multiple special chars in a title", () => {
+    const raw = "OpenCode (myproject)"
+    const escaped = escapeMarkdownV2(raw)
+    expect(escaped).toBe("OpenCode \\(myproject\\)")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sendToChannel - uses a mocked global fetch
+// ---------------------------------------------------------------------------
+describe("sendToChannel", () => {
+  const opts = { title: "OpenCode", message: "Session completed" }
+
+  let fetchSpy: ReturnType<typeof spyOn>
+  let stderrSpy: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 200 }) as Response
+    )
+    stderrSpy = spyOn(process.stderr, "write").mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+    stderrSpy.mockRestore()
+  })
+
+  // -- Gotify --
+  test("sends a POST to <url>/message with correct headers for gotify", async () => {
+    const channel: GotifyChannelConfig = {
+      type: "gotify",
+      url: "https://gotify.example.com",
+      token: "mytoken",
+    }
+
+    await sendToChannel(channel, opts)
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe("https://gotify.example.com/message")
+    expect(init.method).toBe("POST")
+    expect((init.headers as Record<string, string>)["X-Gotify-Key"]).toBe("mytoken")
+    const body = JSON.parse(init.body as string)
+    expect(body.title).toBe("OpenCode")
+    expect(body.message).toBe("Session completed")
+    expect(body.priority).toBe(5) // default priority
+  })
+
+  test("uses custom priority for gotify", async () => {
+    const channel: GotifyChannelConfig = {
+      type: "gotify",
+      url: "https://gotify.example.com",
+      token: "tok",
+      priority: 8,
+    }
+
+    await sendToChannel(channel, opts)
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(init.body as string)
+    expect(body.priority).toBe(8)
+  })
+
+  test("strips trailing slash from gotify url", async () => {
+    const channel: GotifyChannelConfig = {
+      type: "gotify",
+      url: "https://gotify.example.com/",
+      token: "tok",
+    }
+
+    await sendToChannel(channel, opts)
+
+    const [url] = fetchSpy.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe("https://gotify.example.com/message")
+  })
+
+  test("logs to stderr and does not throw on gotify error response", async () => {
+    fetchSpy.mockResolvedValue(new Response("Unauthorized", { status: 401 }) as Response)
+
+    const channel: GotifyChannelConfig = {
+      type: "gotify",
+      url: "https://gotify.example.com",
+      token: "bad",
+    }
+
+    await expect(sendToChannel(channel, opts)).resolves.toBeUndefined()
+    expect(stderrSpy).toHaveBeenCalled()
+  })
+
+  // -- Telegram --
+  test("sends a POST to telegram sendMessage with MarkdownV2", async () => {
+    const channel: TelegramChannelConfig = {
+      type: "telegram",
+      token: "bottoken",
+      chatId: "12345",
+    }
+
+    await sendToChannel(channel, opts)
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe("https://api.telegram.org/botbottoken/sendMessage")
+    const body = JSON.parse(init.body as string)
+    expect(body.chat_id).toBe("12345")
+    expect(body.parse_mode).toBe("MarkdownV2")
+    // title should be bold (escaped)
+    expect(body.text).toContain("OpenCode")
+  })
+
+  test("escapes special chars in telegram message", async () => {
+    const channel: TelegramChannelConfig = {
+      type: "telegram",
+      token: "tok",
+      chatId: 999,
+    }
+
+    await sendToChannel(channel, { title: "OpenCode (proj)", message: "Done." })
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(init.body as string)
+    expect(body.text).toContain("\\(proj\\)")
+    expect(body.text).toContain("Done\\.")
+  })
+
+  test("logs to stderr and does not throw on telegram error response", async () => {
+    fetchSpy.mockResolvedValue(new Response("Bad Request", { status: 400 }) as Response)
+
+    const channel: TelegramChannelConfig = {
+      type: "telegram",
+      token: "bad",
+      chatId: "1",
+    }
+
+    await expect(sendToChannel(channel, opts)).resolves.toBeUndefined()
+    expect(stderrSpy).toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sendExternalNotifications
+// ---------------------------------------------------------------------------
+describe("sendExternalNotifications", () => {
+  let fetchSpy: ReturnType<typeof spyOn>
+  let stderrSpy: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 200 }) as Response
+    )
+    stderrSpy = spyOn(process.stderr, "write").mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+    stderrSpy.mockRestore()
+  })
+
+  test("does nothing when channels array is empty", async () => {
+    await sendExternalNotifications([], { title: "T", message: "M" })
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  test("calls fetch once per channel", async () => {
+    const channels = [
+      { type: "gotify" as const, url: "https://g.example.com", token: "t1" },
+      { type: "telegram" as const, token: "t2", chatId: "1" },
+    ]
+
+    await sendExternalNotifications(channels, { title: "T", message: "M" })
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+
+  test("continues sending to remaining channels if one fails", async () => {
+    fetchSpy
+      .mockRejectedValueOnce(new Error("network error"))
+      .mockResolvedValue(new Response(null, { status: 200 }) as Response)
+
+    const channels = [
+      { type: "gotify" as const, url: "https://g.example.com", token: "t1" },
+      { type: "telegram" as const, token: "t2", chatId: "1" },
+    ]
+
+    await sendExternalNotifications(channels, { title: "T", message: "M" })
+    // Both channels should have been attempted
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+    expect(stderrSpy).toHaveBeenCalled()
+  })
+})

--- a/src/external-notify.ts
+++ b/src/external-notify.ts
@@ -1,0 +1,126 @@
+/**
+ * External notification channels (Gotify, Telegram, etc.)
+ *
+ * Each channel is configured independently in opencode-notifier.json under
+ * the `externalChannels` array. By default the array is empty and no external
+ * notifications are sent.
+ *
+ * Supported channel types:
+ *   - "gotify"  : Gotify push notification server
+ *   - "telegram": Telegram Bot API
+ */
+
+export type ExternalChannelType = "gotify" | "telegram"
+
+export interface GotifyChannelConfig {
+  type: "gotify"
+  /** Base URL of the Gotify server, e.g. "https://gotify.example.com" */
+  url: string
+  /** Application token */
+  token: string
+  /** Message priority (optional, default 5) */
+  priority?: number
+}
+
+export interface TelegramChannelConfig {
+  type: "telegram"
+  /** Bot API token from @BotFather */
+  token: string
+  /** Chat ID (user, group, or channel) to send messages to */
+  chatId: string | number
+}
+
+export type ExternalChannelConfig = GotifyChannelConfig | TelegramChannelConfig
+
+export interface ExternalNotifyOptions {
+  title: string
+  message: string
+}
+
+async function sendGotify(channel: GotifyChannelConfig, opts: ExternalNotifyOptions): Promise<void> {
+  const baseUrl = channel.url.replace(/\/$/, "")
+  const url = `${baseUrl}/message`
+  const priority = typeof channel.priority === "number" ? channel.priority : 5
+
+  const body = JSON.stringify({
+    title: opts.title,
+    message: opts.message,
+    priority,
+  })
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Gotify-Key": channel.token,
+    },
+    body,
+  })
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "")
+    throw new Error(`Gotify request failed: ${response.status} ${response.statusText} ${text}`.trim())
+  }
+}
+
+async function sendTelegram(channel: TelegramChannelConfig, opts: ExternalNotifyOptions): Promise<void> {
+  const url = `https://api.telegram.org/bot${channel.token}/sendMessage`
+  const text = `*${escapeMarkdownV2(opts.title)}*\n${escapeMarkdownV2(opts.message)}`
+
+  const body = JSON.stringify({
+    chat_id: channel.chatId,
+    text,
+    parse_mode: "MarkdownV2",
+  })
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+  })
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "")
+    throw new Error(`Telegram request failed: ${response.status} ${response.statusText} ${text}`.trim())
+  }
+}
+
+/**
+ * Escape special characters for Telegram MarkdownV2 parse mode.
+ * https://core.telegram.org/bots/api#markdownv2-style
+ */
+export function escapeMarkdownV2(text: string): string {
+  return text.replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, "\\$&")
+}
+
+/**
+ * Send a notification to a single external channel.
+ * Errors are caught and logged to stderr so one failing channel does not
+ * block others.
+ */
+export async function sendToChannel(channel: ExternalChannelConfig, opts: ExternalNotifyOptions): Promise<void> {
+  try {
+    if (channel.type === "gotify") {
+      await sendGotify(channel, opts)
+    } else if (channel.type === "telegram") {
+      await sendTelegram(channel, opts)
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    process.stderr.write(`[opencode-notifier] external channel (${channel.type}) error: ${msg}\n`)
+  }
+}
+
+/**
+ * Send a notification to all configured external channels in parallel.
+ */
+export async function sendExternalNotifications(
+  channels: ExternalChannelConfig[],
+  opts: ExternalNotifyOptions
+): Promise<void> {
+  if (channels.length === 0) {
+    return
+  }
+
+  await Promise.allSettled(channels.map((ch) => sendToChannel(ch, opts)))
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -201,7 +201,15 @@ async function handleEvent(
 
   if (config.externalChannels.length > 0) {
     const title = getNotificationTitle(config, projectName)
-    promises.push(sendExternalNotifications(config.externalChannels, { title, message }))
+    // Always include session title in external notifications regardless of showSessionTitle
+    const externalMessage = interpolateMessage(rawMessage, {
+      sessionTitle,
+      agentName,
+      projectName,
+      timestamp,
+      turn,
+    })
+    promises.push(sendExternalNotifications(config.externalChannels, { title, message: externalMessage }))
   }
 
   if (isEventSoundEnabled(config, eventType)) {
@@ -466,7 +474,7 @@ async function handleEventWithElapsedTime(
   }
 
   let sessionTitle: string | null = preloadedSessionTitle ?? null
-  const shouldLookupSessionInfo = sessionID && !sessionTitle && (config.showSessionTitle || shouldResolveAgentNameForEvent(config, eventType))
+  const shouldLookupSessionInfo = sessionID && !sessionTitle && (config.showSessionTitle || config.externalChannels.length > 0 || shouldResolveAgentNameForEvent(config, eventType))
   if (shouldLookupSessionInfo) {
     const info = await getSessionInfo(client, sessionID)
     sessionTitle = info.title

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
   isEventNotificationEnabled,
   isEventCommandEnabled,
   isEventBellEnabled,
+  isEventExternalNotificationEnabled,
   getMessage,
   getSoundPath,
   getSoundVolume,
@@ -199,7 +200,7 @@ async function handleEvent(
     promises.push(sendNotification(title, message, config.timeout, iconPath, config.notificationSystem, config.linux.grouping, onNotificationClick))
   }
 
-  if (config.externalChannels.length > 0) {
+  if (config.externalChannels.length > 0 && isEventExternalNotificationEnabled(config, eventType)) {
     const title = getNotificationTitle(config, projectName)
     // Always include session title in external notifications regardless of showSessionTitle
     const externalMessage = interpolateMessage(rawMessage, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { sendNotification } from "./notify"
 import { playSound } from "./sound"
 import { ringBell } from "./bell"
 import { runCommand } from "./command"
+import { sendExternalNotifications } from "./external-notify"
 import { isTerminalFocused, focusTerminal, captureStartupWindowId, isKDEJumpBackSupported } from "./focus"
 import { shouldSuppressPermissionAlert, prunePermissionAlertState } from "./permission-dedupe"
 
@@ -196,6 +197,11 @@ async function handleEvent(
     const iconPath = getIconPath(config)
     const onNotificationClick = isKDEJumpBackSupported() ? () => void focusTerminal() : undefined
     promises.push(sendNotification(title, message, config.timeout, iconPath, config.notificationSystem, config.linux.grouping, onNotificationClick))
+  }
+
+  if (config.externalChannels.length > 0) {
+    const title = getNotificationTitle(config, projectName)
+    promises.push(sendExternalNotifications(config.externalChannels, { title, message }))
   }
 
   if (isEventSoundEnabled(config, eventType)) {


### PR DESCRIPTION
Add support for sending notifications to external services via the externalChannels config array in opencode-notifier.json. Channels are sent to in parallel; errors are logged to stderr and do not block other channels or local notifications. By default the array is empty so existing behaviour is unchanged.

Supported channels:
- gotify: POST to /message with X-Gotify-Key header
- telegram: Telegram Bot API sendMessage with MarkdownV2 escaping

Add src/external-notify.ts with typed channel configs, per-channel senders, and escapeMarkdownV2 helper. Update config.ts to parse and validate externalChannels entries. Update index.ts to call sendExternalNotifications from handleEvent. Add 16 unit tests covering happy path, error responses, and multi-channel scenarios.