### PR TITLE
fix: detect iTerm2 hotkey window as focused on macOS

### DIFF
--- a/src/focus.ts
+++ b/src/focus.ts
@@ -151,6 +151,14 @@ function getMacOSActiveWindowId(): string | null {
 }
 
 function getMacOSFrontmostAppName(): string | null {
+  // Detect frontmost app regardless of activation policy
+  // (apps excluded from Dock and App Switcher)
+  const lsappinfo = execWithTimeout(
+    `lsappinfo info -only name \`lsappinfo front\` | sed 's/.*="\\([^"]*\\)".*/\\1/'`
+  )
+  if (lsappinfo) return lsappinfo
+
+  // Fallback to System Events if lsappinfo is unavailable
   return execWithTimeout(
     `osascript -e 'tell application "System Events" to return name of first application process whose frontmost is true'`
   )


### PR DESCRIPTION
## Summary
Fixes `suppressWhenFocused` not working with iTerm2 hotkey popup windows on macOS.
## Problem
When iTerm2 is configured with "Exclude from Dock and Cmd-Tab Application Switcher" (hotkey popup window mode), `System Events` AppleScript fails to detect iTerm2 as the frontmost application. This causes the plugin to show notifications even when the user is actively interacting with iTerm2.
## Solution
Use `lsappinfo` (built-in macOS CLI) instead of `System Events` AppleScript for frontmost app detection. `lsappinfo` correctly reports iTerm2 as frontmost in this mode.
## Changes
- `src/focus.ts`: `getMacOSFrontmostAppName()` now uses `lsappinfo` as primary method with `System Events` as fallback