### PR TITLE
fix: ensure mpv process exits when stopping playback

### DIFF
--- a/src/sound.ts
+++ b/src/sound.ts
@@ -94,7 +94,18 @@ async function playOnLinux(soundPath: string, volume: number): Promise<void> {
   const players = [
     { command: "paplay", args: [`--volume=${pulseVolume}`, soundPath] },
     { command: "aplay", args: [soundPath] },
-    { command: "mpv", args: ["--no-video", "--no-terminal", "--script-opts=autoload-disabled=yes", `--volume=${percentVolume}`, soundPath] },
+    {
+      command: "mpv",
+      args: [
+        "--no-video",
+        "--no-terminal",
+        "--script-opts=autoload-disabled=yes",
+        "--keep-open=no",
+        "--idle=no",
+        `--volume=${percentVolume}`,
+        soundPath,
+      ],
+    },
     { command: "ffplay", args: ["-nodisp", "-autoexit", "-loglevel", "quiet", "-volume", `${percentVolume}`, soundPath] },
   ]
 


### PR DESCRIPTION
When using `mpv` as the Linux sound backend, if `keep-open=always` and `idle=yes` is set in `~/.config/mpv/mpv.conf`, zombie `mpv` processes will persist even after closing OpenCode. 


<img width="749" height="514" alt="image" src="https://github.com/user-attachments/assets/c2e8dfd5-68be-40e6-99cb-07d14280dd82" />

This is considered as an upstream bug (https://github.com/mpv-player/mpv/issues/17499) and overriding config can be treated as a workaround.

This PR overrides the settings in `mpv.conf` by passing arguments to `mpv` to force `--keep-open=no` and `--idle=no` which has higher priority than the config file so the process exits after playing the notification sound.