### PR TITLE
fix: process idle completion synchronously for CLI sessions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ function incrementTurnCount(): number {
 }
 
 // Memory cleanup: Remove old session entries every 5 minutes to prevent leaks
-setInterval(() => {
+const cleanupInterval = setInterval(() => {
   const cutoff = Date.now() - 5 * 60 * 1000 // 5 minutes ago
 
   // Clean up sessionIdleSequence (use last access time stored separately if needed)
@@ -114,6 +114,7 @@ setInterval(() => {
 
   prunePermissionAlertState(cutoff)
 }, 5 * 60 * 1000)
+cleanupInterval.unref()
 
 function getNotificationTitle(config: NotifierConfig, projectName: string | null): string {
   if (config.showProjectName && projectName) {
@@ -491,9 +492,15 @@ export const NotifierPlugin: Plugin = async ({ client, directory }) => {
   // There is no SDK event that reliably signals client connection from a plugin's
   // perspective, so we approximate it with a short delay after plugin startup.
   // Config is read at fire-time so that any user overrides are respected.
-  setTimeout(() => {
+  // CLI sessions skip the delay since the process may exit before it fires.
+  const isCLI = !clientEnv || clientEnv === "cli"
+  if (isCLI) {
     void handleEvent(getConfig(), "client_connected", projectName, null)
-  }, 100)
+  } else {
+    setTimeout(() => {
+      void handleEvent(getConfig(), "client_connected", projectName, null)
+    }, 100)
+  }
 
   return {
     event: async ({ event }) => {
@@ -534,7 +541,16 @@ export const NotifierPlugin: Plugin = async ({ client, directory }) => {
       if (event.type === "session.idle") {
         const sessionID = getSessionIDFromEvent(event)
         if (sessionID) {
-          scheduleSessionIdle(client, config, projectName, event, sessionID)
+          if (isCLI) {
+            // CLI sessions (opencode run) exit soon after going idle.
+            // Process completion directly to avoid losing the notification
+            // when the process terminates before the debounce timer fires.
+            const idleReceivedAtMs = Date.now()
+            const sequence = bumpSessionIdleSequence(sessionID)
+            await processSessionIdle(client, config, projectName, event, sessionID, sequence, idleReceivedAtMs)
+          } else {
+            scheduleSessionIdle(client, config, projectName, event, sessionID)
+          }
         } else {
           await handleEventWithElapsedTime(client, config, "complete", projectName, event)
         }


### PR DESCRIPTION
# PR: Fix notification lost on CLI sessions due to debounce timer

## Problem

When using `opencode run` (CLI sessions), completion notifications are silently lost. The plugin schedules a 350ms debounce timer on `session.idle`, but CLI processes exit shortly after the session goes idle, killing the timer before it fires.

## Root Cause

`scheduleSessionIdle` uses `setTimeout(..., 350)` to debounce rapid idle/busy transitions. This works well for TUI/Desktop sessions where the process stays alive, but CLI sessions (`opencode run`) exit immediately after the session completes. The pending timer never executes.

## Solution

Detect whether we're in a CLI session (`OPENCODE_CLIENT` not set, or `"cli"`) vs a TUI/Desktop session, and handle each case appropriately:

### session.idle handler

**CLI sessions**: Call `processSessionIdle` directly with `await` instead of scheduling a timer. The existing dual sequence check inside `processSessionIdle` (before and after `getSessionInfo`) already guards against rapid idle/busy transitions during the async SDK call, so skipping the timer does not miss busies.

**TUI/Desktop sessions**: Keep the original `scheduleSessionIdle` with 350ms timer. No behavioral change.

### client_connected event

Same issue: the 100ms `setTimeout` for `client_connected` may not fire before process exit. CLI sessions fire immediately; TUI/Desktop keep the delay.

## Impact Analysis

### For CLI users (`opencode run`)
- ✅ Completion notifications now work (the fix)
- ✅ Client connected event fires immediately (best-effort improvement)
- ⚠️ If a CLI session somehow goes idle and immediately busy again (extremely unlikely in CLI mode), the notification might fire early, then be superseded. The sequence check prevents double-notification.

### For TUI/Desktop users
- ✅ No behavioral change whatsoever
- ✅ 350ms debounce timer still active
- ✅ Guiding principle: "first, do no harm" — zero risk for existing users

## Testing

- [x] Windows: `opencode run` — notification received
- [x] TUI session — notification received after agent completes
- [ ] macOS: `opencode run` — notification received (untested, same logic applies)
- [ ] Linux: `opencode run` — notification received (untested, same logic applies)

## Checklist

- [ ] Tests pass (please advise on test commands)
- [ ] CHANGELOG updated (optional)
