### PR TITLE
fix: avoid shelling osascript notifications

### DIFF
--- a/src/notify.test.ts
+++ b/src/notify.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect } from "bun:test"
-import { formatGhosttyNotificationSequence, parseNotifySendOutputLine } from "./notify"
+import {
+  buildOsascriptNotificationArgs,
+  formatGhosttyNotificationSequence,
+  parseNotifySendOutputLine,
+} from "./notify"
 
 describe("formatGhosttyNotificationSequence", () => {
   test("returns plain OSC 9 outside tmux", () => {
@@ -36,5 +40,22 @@ describe("parseNotifySendOutputLine", () => {
     expect(parseNotifySendOutputLine("0")).toEqual({ type: "id", id: 0 })
     expect(parseNotifySendOutputLine("Focus")).toBeNull()
     expect(parseNotifySendOutputLine("random")).toBeNull()
+  })
+})
+
+describe("buildOsascriptNotificationArgs", () => {
+  test("passes title and message as argv instead of interpolating them into the script", () => {
+    const title = "OpenCode (project ' name)"
+    const message = "done with $(shell-like text)"
+
+    const args = buildOsascriptNotificationArgs(title, message)
+
+    expect(args[0]).toBe("-e")
+    expect(args[1]).toContain("item 1 of argv")
+    expect(args[1]).toContain("item 2 of argv")
+    expect(args[1]).not.toContain(title)
+    expect(args[1]).not.toContain(message)
+    expect(args[2]).toBe(message)
+    expect(args[3]).toBe(title)
   })
 })

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -1,5 +1,5 @@
 import os from "os"
-import { exec, execFile, spawn } from "child_process"
+import { execFile, spawn } from "child_process"
 import notifier from "node-notifier"
 import isWsl from "is-wsl"
 
@@ -228,6 +228,15 @@ export function parseNotifySendOutputLine(
   return null
 }
 
+export function buildOsascriptNotificationArgs(title: string, message: string): string[] {
+  return [
+    "-e",
+    "on run argv\n display notification (item 1 of argv) with title (item 2 of argv)\nend run",
+    message,
+    title,
+  ]
+}
+
 export async function sendNotification(
   title: string,
   message: string,
@@ -272,14 +281,9 @@ export async function sendNotification(
     }
 
     return new Promise((resolve) => {
-      const escapedMessage = message.replace(/"/g, '\\"')
-      const escapedTitle = title.replace(/"/g, '\\"')
-      exec(
-        `osascript -e 'display notification "${escapedMessage}" with title "${escapedTitle}"'`,
-        () => {
-          resolve()
-        }
-      )
+      execFile("osascript", buildOsascriptNotificationArgs(title, message), () => {
+        resolve()
+      })
     })
   }
 


### PR DESCRIPTION
## Summary

- replace the macOS `osascript` notification path with `execFile` so title/message are passed as argv instead of through a shell-built script string
- add coverage that the notification title/message are not interpolated into the AppleScript source

Closes #85.

## Validation

- `bun test src/notify.test.ts`
- `bun run typecheck`
- `bun run build`
- `bun test --timeout 10000` (71 pass; default 5s timeout can be tight for the existing `focusTerminal` test on this machine, which completed in about 6.8s)
