### PR TITLE
feat: support click-to-focus on macOS notifications

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -195,7 +195,7 @@ async function handleEvent(
   if (notificationEnabled) {
     const title = getNotificationTitle(config, projectName)
     const iconPath = getIconPath(config)
-    const onNotificationClick = isKDEJumpBackSupported() ? () => void focusTerminal() : undefined
+    const onNotificationClick = process.platform !== "win32" ? () => void focusTerminal() : undefined
     promises.push(sendNotification(title, message, config.timeout, iconPath, config.notificationSystem, config.linux.grouping, onNotificationClick))
   }
 

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -260,11 +260,15 @@ export async function sendNotification(
           message: message,
           timeout: timeout,
           icon: iconPath,
+          wait: true,
         }
 
         notifier.notify(
           notificationOptions,
-          () => {
+          (err: any, response: any, metadata: any) => {
+            if (!err && onClick && metadata?.activationType !== "timeout") {
+              onClick()
+            }
             resolve()
           }
         )


### PR DESCRIPTION
## Problem

On macOS with `node-notifier` as the notification system, clicking a notification banner dismisses it but does **not** focus the terminal app. This is because:

1. `onNotificationClick` is only active on Linux KDE (`isKDEJumpBackSupported()`), always `undefined` on macOS
2. The macOS `node-notifier` path never inspects click events

## Root Cause Analysis

### 1. `onNotificationClick` is over-gated

```diff
- const onNotificationClick = isKDEJumpBackSupported() ? () => void focusTerminal() : undefined
+ const onNotificationClick = process.platform !== "win32" ? () => void focusTerminal() : undefined
```

`isKDEJumpBackSupported()` requires all three: `linux + KDE_SESSION_VERSION + kdotool available`. Yet `focusTerminal()` already has full, working implementations for **macOS** and **Linux** (all desktop environments):

| Platform | `focusTerminal()` implementation | Called before? |
|----------|----------------------------------|:---:|
| macOS | `osascript activate` for iTerm2, Terminal, etc. | ❌ Never |
| Linux X11 | `xdotool windowactivate` | ❌ (only KDE+kdotool) |
| Linux Wayland | hyprctl / swaymsg / niri per-compositor | ❌ (only KDE+kdotool) |
| Windows | No implementation (empty function) | ❌ N/A |

→ **Change:** enable `onNotificationClick` on all non-Windows platforms to unlock the already-existing capability.

### 2. macOS `node-notifier` path ignores click events

```diff
  const notificationOptions: any = {
    title, message, timeout, icon: iconPath,
+   wait: true,   // keep notification alive until user interacts
  }
  notifier.notify(notificationOptions,
-   () => { resolve() }
+   (err, response, metadata) => {
+     if (!err && onClick && metadata?.activationType !== "timeout") {
+       onClick()
+     }
+     resolve()
+   }
  )
```

Without `wait: true`, the `node-notifier` callback fires immediately upon sending — before the user can interact. With `wait: true`, the callback fires *after* user action (or timeout), and `metadata.activationType` tells us what happened:
- `"timeout"` → notification expired naturally, no focus
- click event → call `onClick()` → `focusTerminal()` → switch to terminal

The Linux/Windows fallback at the bottom of `sendNotification()` already implements the same click-detection pattern. This change brings the macOS path to parity.

## Changes

- **`src/index.ts:198`** — extend `onNotificationClick` from Linux KDE only to all non-Windows platforms
- **`src/notify.ts:258-273`** — add `wait: true` and click detection in the macOS `node-notifier` path

## Testing

- macOS 15 + iTerm2 + `node-notifier` config: clicking notification banner successfully focuses iTerm2 ✅