### PR TITLE
fix: Windows focus detection using class/process name matching

### DIFF
--- a/src/focus.test.ts
+++ b/src/focus.test.ts
@@ -127,10 +127,93 @@ describe("isLinuxTerminalFocused", () => {
 })
 
 describe("isWindowsTerminalFocused", () => {
-  test("matches startup and current foreground window ids", () => {
-    expect(isWindowsTerminalFocused({ cachedWindowId: "123", currentWindowId: "123" })).toBe(true)
-    expect(isWindowsTerminalFocused({ cachedWindowId: "123", currentWindowId: "456" })).toBe(false)
-    expect(isWindowsTerminalFocused({ cachedWindowId: null, currentWindowId: "123" })).toBe(false)
+  test("matches Windows Terminal by class name", () => {
+    expect(isWindowsTerminalFocused({ className: "CASCADIA_HOSTING_WINDOW_CLASS", processName: null })).toBe(true)
+  })
+
+  test("matches Windows Terminal by process name", () => {
+    expect(isWindowsTerminalFocused({ className: null, processName: "WindowsTerminal" })).toBe(true)
+  })
+
+  test("matches conhost by class name", () => {
+    expect(isWindowsTerminalFocused({ className: "ConsoleWindowClass", processName: null })).toBe(true)
+  })
+
+  test("matches conhost by process name", () => {
+    expect(isWindowsTerminalFocused({ className: null, processName: "conhost" })).toBe(true)
+  })
+
+  test("matches Alacritty by process name", () => {
+    expect(isWindowsTerminalFocused({ className: null, processName: "alacritty" })).toBe(true)
+  })
+
+  test("matches WezTerm by process name", () => {
+    expect(isWindowsTerminalFocused({ className: null, processName: "wezterm" })).toBe(true)
+  })
+
+  test("matches VS Code by process name", () => {
+    expect(isWindowsTerminalFocused({ className: null, processName: "Code" })).toBe(true)
+  })
+
+  test("matches cursor by process name", () => {
+    expect(isWindowsTerminalFocused({ className: null, processName: "cursor" })).toBe(true)
+  })
+
+  test("returns false for non-terminal class and process", () => {
+    expect(isWindowsTerminalFocused({ className: "Chrome_WidgetWin_1", processName: "chrome" })).toBe(false)
+  })
+
+  test("returns false when both are null", () => {
+    expect(isWindowsTerminalFocused({ className: null, processName: null })).toBe(false)
+  })
+
+  test("is case insensitive", () => {
+    expect(isWindowsTerminalFocused({ className: "CASCADIA_HOSTING_WINDOW_CLASS", processName: null })).toBe(true)
+    expect(isWindowsTerminalFocused({ className: "cascadia_hosting_window_class", processName: null })).toBe(true)
+    expect(isWindowsTerminalFocused({ className: null, processName: "WindowsTerminal" })).toBe(true)
+    expect(isWindowsTerminalFocused({ className: null, processName: "windowsterminal" })).toBe(true)
+  })
+
+  test("matches when either class or process name matches", () => {
+    expect(isWindowsTerminalFocused({ className: "CASCADIA_HOSTING_WINDOW_CLASS", processName: "chrome" })).toBe(true)
+    expect(isWindowsTerminalFocused({ className: "Chrome_WidgetWin_1", processName: "WindowsTerminal" })).toBe(true)
+  })
+})
+
+describe("getWindowsActiveWindowInfo on Windows", () => {
+  test("PowerShell command produces valid 'class|process' output", () => {
+    // Only run this test on Windows (the P/Invoke won't work elsewhere)
+    // This is an integration test that verifies the actual PowerShell command
+    // works correctly — catches Win32 API issues, CLIXML problems, etc.
+    const { execFileSync } = require("child_process")
+    const script = `
+$p=Add-Type -Name NFI_Test -Namespace OpenCodeNotifier -MemberDefinition '[DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();[DllImport("user32.dll", CharSet=CharSet.Auto)] public static extern int GetClassName(IntPtr h,System.Text.StringBuilder b,int n);[DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h,out uint p);' -PassThru;
+$h=$p::GetForegroundWindow();
+if(!$h){Write-Output 'null|null';return}
+$sb=New-Object System.Text.StringBuilder 256;
+$p::GetClassName($h,$sb,256)|Out-Null;
+$c=$sb.ToString();
+$procId=0;
+$p::GetWindowThreadProcessId($h,[ref]$procId)|Out-Null;
+try{$pn=(Get-Process -Id $procId -ErrorAction SilentlyContinue).ProcessName}catch{}
+if(!$pn){$pn=''}
+Write-Output "$c|$pn"
+`.trim().replace(/\n/g, "; ")
+
+    const result = execFileSync("powershell", ["-NoProfile", "-NonInteractive", "-Command", script], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5000,
+      windowsHide: true,
+    }).trim()
+
+    // The result must contain '|' and must have a non-empty process name
+    expect(result).toContain("|")
+    const [className, processName] = result.split("|")
+    expect(className).toBeTruthy()
+    expect(processName).toBeTruthy()
+    // Class name should be a real Windows window class (at least 3 chars)
+    expect(className.length).toBeGreaterThan(2)
   })
 })
 

--- a/src/focus.ts
+++ b/src/focus.ts
@@ -136,12 +136,76 @@ function getLinuxWaylandActiveWindowId(): string | null {
   return null
 }
 
-function getWindowsActiveWindowId(): string | null {
-  const script = `$type=Add-Type -Name FocusHelper -Namespace OpenCodeNotifier -MemberDefinition '[DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();' -PassThru; $type::GetForegroundWindow()`;
-  let windowId = execFileWithTimeout("powershell", ["-NoProfile", "-NonInteractive", "-Command", script], 1000)
-  if (!windowId)
-    windowId = execFileWithTimeout("pwsh", ["-NoProfile", "-NonInteractive", "-Command", script], 1000)
-  return windowId
+const WINDOWS_TERMINAL_WINDOW_CLASSES = new Set<string>([
+  "cascadia_hosting_window_class",
+  "consolewindowclass",
+  "windowsterminalwindowclass",
+])
+
+const WINDOWS_TERMINAL_PROCESS_NAMES = new Set<string>([
+  "windowsterminal",
+  "windowsterminalpreview",
+  "conhost",
+  "alacritty",
+  "wezterm",
+  "wezterm-gui",
+  "kitty",
+  "hyper",
+  "cursor",
+  "code",
+  "code - insiders",
+])
+
+interface WindowsWindowInfo {
+  className: string | null
+  processName: string | null
+}
+
+export function prewarmWindowsPowerShellType(): void {
+  if (process.platform !== "win32") return
+  const warmupScript = `
+$p=Add-Type -Name NFI -Namespace OpenCodeNotifier -MemberDefinition '[DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();[DllImport("user32.dll", CharSet=CharSet.Auto)] public static extern int GetClassName(IntPtr h,System.Text.StringBuilder b,int n);[DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h,out uint p);' -PassThru;
+Write-Output "ok"
+`.trim().replace(/\n/g, "; ")
+  try {
+    execFile("powershell", ["-NoProfile", "-NonInteractive", "-Command", warmupScript], {
+      timeout: 5000,
+      windowsHide: true,
+    })
+  } catch {}
+}
+
+function getWindowsActiveWindowInfo(): WindowsWindowInfo | null {
+  const script = `
+$p=Add-Type -Name NFI -Namespace OpenCodeNotifier -MemberDefinition '[DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();[DllImport("user32.dll", CharSet=CharSet.Auto)] public static extern int GetClassName(IntPtr h,System.Text.StringBuilder b,int n);[DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h,out uint p);' -PassThru;
+$h=$p::GetForegroundWindow();
+if(!$h){return}
+$sb=New-Object System.Text.StringBuilder 256;
+$p::GetClassName($h,$sb,256)|Out-Null;
+$c=$sb.ToString();
+$procId=0;
+$p::GetWindowThreadProcessId($h,[ref]$procId)|Out-Null;
+$pn='';
+try{$pn=(Get-Process -Id $procId -ErrorAction SilentlyContinue).ProcessName}catch{}
+Write-Output "$c|$pn"
+`.trim().replace(/\n/g, "; ")
+  let output = execFileWithTimeout("powershell", ["-NoProfile", "-NonInteractive", "-Command", script], 5000)
+  if (!output)
+    output = execFileWithTimeout("pwsh", ["-NoProfile", "-NonInteractive", "-Command", script], 1000)
+  if (!output) return null
+  const sep = output.indexOf("|")
+  if (sep === -1) return null
+  const className = output.substring(0, sep) || null
+  const processName = output.substring(sep + 1) || null
+  return { className, processName }
+}
+
+function isWindowsTerminalForeground(): boolean {
+  const info = getWindowsActiveWindowInfo()
+  if (!info) return false
+  const className = info.className?.toLowerCase() ?? ""
+  const processName = info.processName?.toLowerCase() ?? ""
+  return WINDOWS_TERMINAL_WINDOW_CLASSES.has(className) || WINDOWS_TERMINAL_PROCESS_NAMES.has(processName)
 }
 
 function getMacOSActiveWindowId(): string | null {
@@ -225,7 +289,7 @@ function getActiveWindowId(): string | null {
     if (process.env.DISPLAY) return execWithTimeout("xdotool getactivewindow")
     return null
   }
-  if (platform === "win32") return getWindowsActiveWindowId()
+  if (platform === "win32") return null
   return null
 }
 
@@ -272,11 +336,13 @@ export function isLinuxTerminalFocused(params: {
 }
 
 export function isWindowsTerminalFocused(params: {
-  cachedWindowId: string | null
-  currentWindowId: string | null
+  className: string | null
+  processName: string | null
 }): boolean {
-  const { cachedWindowId, currentWindowId } = params
-  return !!cachedWindowId && currentWindowId === cachedWindowId
+  const { className, processName } = params
+  const classLower = className?.toLowerCase() ?? ""
+  const processLower = processName?.toLowerCase() ?? ""
+  return WINDOWS_TERMINAL_WINDOW_CLASSES.has(classLower) || WINDOWS_TERMINAL_PROCESS_NAMES.has(processLower)
 }
 
 function isTmuxPaneActive(): boolean {
@@ -312,9 +378,10 @@ export function isTerminalFocused(): boolean {
     }
 
     if (process.platform === "win32") {
+      const info = getWindowsActiveWindowInfo()
       return isWindowsTerminalFocused({
-        cachedWindowId,
-        currentWindowId: getWindowsActiveWindowId(),
+        className: info?.className ?? null,
+        processName: info?.processName ?? null,
       })
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import { sendNotification } from "./notify"
 import { playSound } from "./sound"
 import { ringBell } from "./bell"
 import { runCommand } from "./command"
-import { isTerminalFocused, focusTerminal, captureStartupWindowId, isKDEJumpBackSupported } from "./focus"
+import { isTerminalFocused, focusTerminal, captureStartupWindowId, isKDEJumpBackSupported, prewarmWindowsPowerShellType } from "./focus"
 import { shouldSuppressPermissionAlert, prunePermissionAlertState } from "./permission-dedupe"
 
 const IDLE_COMPLETE_DELAY_MS = 350
@@ -476,6 +476,7 @@ async function handleEventWithElapsedTime(
 }
 
 export const NotifierPlugin: Plugin = async ({ client, directory }) => {
+  prewarmWindowsPowerShellType()
   captureStartupWindowId()
 
   const clientEnv = process.env.OPENCODE_CLIENT


### PR DESCRIPTION
Replaces HWND-comparison with name-based terminal detection (same pattern as macOS).

Fixes #81.

Fixes:
1. Read-only 13748 variable renamed 
2. GetClassNameW changed to GetClassName with CharSet.Auto (fixes marshaling)
3. Added class/process name matching against known terminal identifiers

Tests: 82 pass including real PowerShell integration test