### PR TITLE
fix: avoid shelling osascript app-activate in focusTerminal

### DIFF
--- a/src/focus.test.ts
+++ b/src/focus.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test"
-import { isLinuxTerminalFocused, isMacTerminalAppFocused, isTmuxPaneFocused, parseWezTermFocusedPaneId, isKDEJumpBackSupported, captureStartupWindowId, focusTerminal, getCachedWindowTitle, isWindowsTerminalFocused } from "./focus"
+import { isLinuxTerminalFocused, isMacTerminalAppFocused, isTmuxPaneFocused, parseWezTermFocusedPaneId, isKDEJumpBackSupported, captureStartupWindowId, focusTerminal, getCachedWindowTitle, isWindowsTerminalFocused, buildOsascriptActivateAppArgs } from "./focus"
 
 describe("isMacTerminalAppFocused", () => {
   test("matches Terminal when TERM_PROGRAM is Apple_Terminal", () => {
@@ -208,5 +208,14 @@ describe("captureStartupWindowId", () => {
 describe("focusTerminal", () => {
   test("does not throw on unsupported platforms", async () => {
     await expect(focusTerminal()).resolves.toBeUndefined()
+  })
+})
+
+describe("buildOsascriptActivateAppArgs", () => {
+  test("passes the app name into the script arg instead of shell interpolation", () => {
+    const appName = `App';touch pwned;'`
+    const args = buildOsascriptActivateAppArgs(appName)
+    expect(args[0]).toBe("-e")
+    expect(args[1]).toBe(`tell application "${appName}" to activate`)
   })
 })

--- a/src/focus.ts
+++ b/src/focus.ts
@@ -203,6 +203,13 @@ function getExpectedMacTerminalAppNames(env: NodeJS.ProcessEnv): Set<string> {
   return new Set(MAC_TERMINAL_APP_NAMES)
 }
 
+export function buildOsascriptActivateAppArgs(appName: string): string[] {
+  return [
+    "-e",
+    `tell application "${appName}" to activate`,
+  ]
+}
+
 export function isMacTerminalAppFocused(frontmostAppName: string | null, env: NodeJS.ProcessEnv = process.env): boolean {
   if (!frontmostAppName) {
     return false
@@ -739,12 +746,12 @@ export async function focusTerminal(): Promise<void> {
       const expectedApps = getExpectedMacTerminalAppNames(process.env)
       for (const app of expectedApps) {
         try {
-          execSync(`osascript -e 'tell application "${app}" to activate' 2>/dev/null`, { timeout: 1000 })
+          execFileSync("osascript", buildOsascriptActivateAppArgs(app), { timeout: 1000, stdio: "ignore" })
           return
         } catch {
         }
       }
-      execSync(`osascript -e 'tell application "Terminal" to activate' 2>/dev/null`, { timeout: 1000 })
+      execFileSync("osascript", buildOsascriptActivateAppArgs("Terminal"), { timeout: 1000, stdio: "ignore" })
     } catch {
     }
     return


### PR DESCRIPTION
## Summary

- extend the #88 / #85 argv hardening to the macOS `focusTerminal` path in `src/focus.ts`
- `execSync` shell strings that interpolated the terminal app name (derived from `TERM_PROGRAM`, i.e. attacker-influenced env) now use `execFileSync('osascript', buildOsascriptActivateAppArgs(app))` so the name is passed as argv
- add unit test asserting the app name is embedded in the script arg rather than a shell-interpolated string

## Validation

- `bun run typecheck`
- `bun test src/focus.test.ts src/notify.test.ts` (38 pass)
